### PR TITLE
build: ensure WebP/AVIF siblings for proficiency logos

### DIFF
--- a/functions/edge-computing.js
+++ b/functions/edge-computing.js
@@ -282,6 +282,7 @@ const WorkerApp = {
         };
         console.warn('🔐 CSP violation report:', record);
         const key = `csp:${record.t}:${Math.random().toString(36).slice(2, 8)}`;
+        // Prefer dedicated storage; if not configured, this is a best-effort no-op
         if (env.CSP_REPORTS && typeof env.CSP_REPORTS.put === 'function') {
           await env.CSP_REPORTS.put(key, JSON.stringify(record), { expirationTtl: 60 * 60 * 24 * 7 });
         } else if (env.RATE_LIMIT_KV && typeof env.RATE_LIMIT_KV.put === 'function') {

--- a/functions/edge-computing.js
+++ b/functions/edge-computing.js
@@ -133,7 +133,24 @@ class EdgePerformanceOptimizer {
       'manifest-src \'self\'',
       'worker-src \'self\''
     ];
+    // Primary enforcing CSP
     headers.set('Content-Security-Policy', csp.join('; '));
+
+    // Report-Only CSP rollout (matched to current policy for baseline; can be tightened later)
+    const reportEndpoint = (() => {
+      try { return new URL('/csp-report', this.url).toString(); } catch { return '/csp-report'; }
+    })();
+    const cspReportOnly = [
+      ...csp,
+      `report-uri ${reportEndpoint}`,
+      'report-to csp'
+    ];
+    // Modern reporting headers
+    try {
+      headers.set('Reporting-Endpoints', `csp="${reportEndpoint}"`);
+      headers.set('Report-To', JSON.stringify({ group: 'csp', max_age: 60 * 60 * 24 * 30, endpoints: [{ url: reportEndpoint }], include_subdomains: true }));
+    } catch { /* ignore header json errors */ }
+    headers.set('Content-Security-Policy-Report-Only', cspReportOnly.join('; '));
   if (isAudit) headers.set('X-Audit-Mode', '1');
     if (cspNonce) headers.set('X-CSP-Nonce', cspNonce);
     headers.set('X-Frame-Options', 'DENY');
@@ -237,6 +254,44 @@ const WorkerApp = {
       } catch {
         return new Response('User-agent: *\nAllow: /\n', { status: 200, headers: { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'public, max-age=300, no-transform' } });
       }
+    }
+
+    // CSP violation report collection endpoint
+    if (url.pathname === '/csp-report') {
+      if (request.method !== 'POST') {
+        return new Response(null, { status: 405, headers: { 'allow': 'POST', 'cache-control': 'no-store' } });
+      }
+      try {
+        const ct = (request.headers.get('content-type') || '').toLowerCase();
+        let bodyText = await request.text();
+        let payload;
+        try {
+          payload = JSON.parse(bodyText);
+        } catch {
+          payload = { raw: bodyText };
+        }
+        // Normalize legacy report format
+        const report = payload?.['csp-report'] ? { type: 'csp-report', ...payload['csp-report'] } : payload;
+        const record = {
+          t: Date.now(),
+          url: request.url,
+          ip: request.headers.get('cf-connecting-ip') || null,
+          ua: request.headers.get('user-agent') || null,
+          ct,
+          report
+        };
+        console.warn('🔐 CSP violation report:', record);
+        const key = `csp:${record.t}:${Math.random().toString(36).slice(2, 8)}`;
+        if (env.CSP_REPORTS && typeof env.CSP_REPORTS.put === 'function') {
+          await env.CSP_REPORTS.put(key, JSON.stringify(record), { expirationTtl: 60 * 60 * 24 * 7 });
+        } else if (env.RATE_LIMIT_KV && typeof env.RATE_LIMIT_KV.put === 'function') {
+          // Fallback storage if dedicated KV is not bound
+          await env.RATE_LIMIT_KV.put(key, JSON.stringify(record), { expirationTtl: 60 * 60 * 24 * 3 });
+        }
+      } catch (e) {
+        console.error('Failed to store CSP report:', e);
+      }
+      return new Response(null, { status: 204, headers: { 'cache-control': 'no-store' } });
     }
 
     // Health endpoint (moved off /metrics to avoid third-party collisions)

--- a/scripts/build/performance-budget.sh
+++ b/scripts/build/performance-budget.sh
@@ -87,7 +87,9 @@ IMAGE_CANDIDATES=$(find "$BUILD_DIR/assets/images" -type f \( -iname "*.jpg" -o 
 
 UNOPTIMIZED_LIST=""
 COUNT=0
-for img in $IMAGE_CANDIDATES; do
+# Iterate over candidates line-by-line to support spaces in filenames
+while IFS= read -r img; do
+    [ -z "$img" ] && continue
     base_no_ext="${img%.*}"
     if [ -f "${base_no_ext}.webp" ] || [ -f "${base_no_ext}.avif" ]; then
         continue
@@ -95,7 +97,9 @@ for img in $IMAGE_CANDIDATES; do
     UNOPTIMIZED_LIST+="$img\n"
     COUNT=$((COUNT+1))
     if [ $COUNT -ge 5 ]; then break; fi
-done
+done <<EOF
+$IMAGE_CANDIDATES
+EOF
 
 if [ $COUNT -gt 0 ]; then
     echo "⚠️ Warning: Found potentially unoptimized images (no WebP/AVIF sibling):"

--- a/scripts/build/postbuild-copy.js
+++ b/scripts/build/postbuild-copy.js
@@ -1,6 +1,6 @@
-import { cpSync, existsSync, writeFileSync, readdirSync, statSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
-import { readFileSync, mkdirSync } from 'node:fs';
+import { cpSync, existsSync, writeFileSync, readdirSync, statSync, unlinkSync, mkdirSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { readFileSync } from 'node:fs';
 
 const dist = join(process.cwd(), 'dist');
 
@@ -71,6 +71,29 @@ try {
   }
 } catch {
   // non-blocking; skip if search files not present
+}
+
+// Ensure WebP/AVIF siblings for proficiency logos exist alongside PNGs in dist
+try {
+  const srcProfs = join(process.cwd(), 'src', 'assets', 'images', 'proficiencies');
+  const distProfs = join(dist, 'assets', 'images', 'proficiencies');
+  if (existsSync(srcProfs) && existsSync(distProfs)) {
+    const srcEntries = readdirSync(srcProfs);
+    // Copy over any .webp or .avif from src if not present in dist
+    for (const name of srcEntries) {
+      const ext = extname(name).toLowerCase();
+      if (ext === '.webp' || ext === '.avif') {
+        const srcPath = join(srcProfs, name);
+        const destPath = join(distProfs, name);
+        if (!existsSync(destPath)) {
+          cpSync(srcPath, destPath);
+          console.log(`Copied optimized logo format: assets/images/proficiencies/${name}`);
+        }
+      }
+    }
+  }
+} catch {
+  // ignore if copying optimized logo formats fails
 }
 
 // Remove any oversized PNG artifacts that could exceed Cloudflare's 25 MiB asset limit

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -30,5 +30,9 @@ id      = "65439bda285f486f9b07fc2a30bc5099"
 binding = "CONTACT_MESSAGES"
 id      = "65439bda285f486f9b07fc2a30bc5099"
 
+[[kv_namespaces]]
+binding = "CSP_REPORTS"
+id      = "65439bda285f486f9b07fc2a30bc5099"
+
 [observability.logs]
 enabled = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -30,9 +30,10 @@ id      = "65439bda285f486f9b07fc2a30bc5099"
 binding = "CONTACT_MESSAGES"
 id      = "65439bda285f486f9b07fc2a30bc5099"
 
-[[kv_namespaces]]
-binding = "CSP_REPORTS"
-id      = "65439bda285f486f9b07fc2a30bc5099"
+# To enable CSP report persistence, create a KV namespace and add it here:
+# [[kv_namespaces]]
+# binding = "CSP_REPORTS"
+# id      = "<your-kv-namespace-id>"
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
- **security(csp): add CSP Report-Only with Reporting-Endpoints and /csp-report collector; persist reports to KV; keep a11y green**
- **chore(csp): make KV optional; document how to enable CSP_REPORTS later; keep endpoint non-fatal**
- **build: ensure WebP/AVIF siblings for proficiency logos + fix perf budget space-safe scan**
