### PR TITLE
ci(actions): trim weekly workflow breadth

### DIFF
--- a/.github/workflows/ci-comprehensive.yml
+++ b/.github/workflows/ci-comprehensive.yml
@@ -4,9 +4,6 @@ name: Comprehensive CI
 on:
   push:
     branches: [main]
-  schedule:
-    # Run comprehensive tests weekly on Sunday at 2 AM UTC (reduced from nightly)
-    - cron: '0 2 * * 0'
   workflow_dispatch:
     # Allow manual triggering for comprehensive testing
 
@@ -35,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false  # Continue other tests even if one fails
       matrix:
-        test-group: [unit, e2e, performance]
+        test-group: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["unit","e2e","performance"]' || '["unit","e2e"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/reliability-weekly.yml
+++ b/.github/workflows/reliability-weekly.yml
@@ -23,11 +23,15 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build site
         run: pnpm build
-      - name: Install Playwright Browsers
-        run: pnpm test:e2e:install
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Install Firefox
+        if: github.event_name == 'workflow_dispatch'
+        run: pnpm exec playwright install --with-deps firefox
       - name: Run essential tests (Chromium)
         run: npx playwright test --grep "@essential" --project=chromium --reporter=line,json --output=test-results/chromium
       - name: Run essential tests (Firefox)
+        if: github.event_name == 'workflow_dispatch'
         run: npx playwright test --grep "@essential" --project=firefox --reporter=line,json --output=test-results/firefox
       - name: Upload artifacts
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
- remove the scheduled comprehensive CI run
- keep comprehensive depth on manual dispatch
- make weekly reliability Chromium-first, with Firefox reserved for manual runs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>