### PR TITLE
Restore home hero coin-flip circle with floating icons

### DIFF
--- a/src/components/features/home/HomeHeroSection.astro
+++ b/src/components/features/home/HomeHeroSection.astro
@@ -1,7 +1,9 @@
 ---
+import CoinFlipImage from '../../composites/CoinFlipImage.astro';
 import PageHero from '../../composites/PageHero.astro';
 import Button from '../../primitives/Button.astro';
 import ButtonGroup from '../../composites/ButtonGroup.astro';
+import FloatingEmoji from '../../primitives/FloatingEmoji.astro';
 
 interface Props {
   author: string;
@@ -12,8 +14,8 @@ interface Props {
 const { author, tagline, description } = Astro.props as Props;
 ---
 
-<PageHero id="about-me">
-  <div class="grid items-center gap-10 md:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)] sm:gap-12 lg:gap-16">
+<PageHero id="about-me" class="hero-gradient-animated">
+  <div class="grid items-center gap-10 md:grid-cols-2 sm:gap-12 lg:gap-16">
     <div class="order-2 md:order-1">
       <div class="max-w-2xl space-y-8 text-base leading-relaxed text-foreground/85">
         <div class="space-y-5">
@@ -56,33 +58,26 @@ const { author, tagline, description } = Astro.props as Props;
       </ButtonGroup>
     </div>
     <div class="order-1 flex justify-center md:order-2 md:justify-end">
-      <div class="proof-card max-w-sm p-6 sm:p-8">
-        <div class="relative z-10 space-y-6">
-          <div class="overflow-hidden rounded-3xl border border-border/50 bg-surface shadow-sm">
-            <picture>
-              <source srcset="/assets/images/optimized/avif/Blake-O-scaled@640w.avif" type="image/avif" />
-              <source srcset="/assets/images/optimized/webp/Blake-O-scaled@640w.webp" type="image/webp" />
-              <img
-                src="/assets/images/Blake-O-scaled.jpg"
-                alt="Blake Oxford"
-                class="aspect-[4/5] w-full object-cover"
-                width="640"
-                height="800"
-                loading="eager"
-                fetchpriority="high"
-                decoding="async"
-              />
-            </picture>
-          </div>
-          <div class="space-y-3">
-            <p class="text-xs font-semibold uppercase tracking-[0.18em] text-subtle-foreground">Operating profile</p>
-            <ul class="space-y-2 text-sm leading-relaxed text-foreground/88 sm:text-base" role="list">
-              <li>Builds durable systems with low cognitive load.</li>
-              <li>Combines technical implementation with operational adoption.</li>
-              <li>Prioritizes control integrity over novelty.</li>
-            </ul>
-          </div>
+      <div class="relative">
+        <div class="absolute -inset-4 rounded-full bg-gradient-to-r from-accent/30 to-primary/30 blur-xl opacity-70 animate-pulse"></div>
+        <div class="relative rounded-full bg-gradient-to-r from-accent to-primary p-1">
+          <CoinFlipImage
+            frontSrc="/assets/images/Blake-O-scaled.jpg"
+            backSrc="/assets/images/china-profile-picture.jpg"
+            alt="Blake Oxford"
+            altBack="Blake Oxford in China"
+            size={280}
+            flipMultipleTimes
+            loading="eager"
+            fetchPriority="high"
+            decoding="auto"
+            role="img"
+            aria-label="Photo of Blake Oxford"
+          />
         </div>
+        <FloatingEmoji emoji="💡" position="top-right" size="md" />
+        <FloatingEmoji emoji="🚀" position="bottom-left" size="sm" color="accent-dark" />
+        <FloatingEmoji emoji="☁️" position="center-right" size="sm" color="primary" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the home hero visual the user preferred: the animated circular coin-flip photo (Blake + China profile) with floating emoji accents (💡 🚀 ☁️) and the `hero-gradient-animated` background.

The static proof-card layout replaced this in the UI polish refactor (`451fe074`). This change brings back the interactive hero while keeping the updated copy, strengths list, and CTAs from the recent polish pass.

## Type

- [x] feat

## Quality Gates

- [x] Lint/typecheck pass (pre-push hook)
- [x] Build pass
- [x] Deployed manually to Cloudflare (version `1498569e-c3b2-4e43-9775-91e8d980e72a`)

## Risks & Rollback

Low risk — reuses existing `CoinFlipImage`, `FloatingEmoji`, and `.hero-gradient-animated` styles already in the codebase. Revert this single-file change if the hero needs to go back to the proof-card layout.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f24f8-7e75-709b-b769-90f099f16e4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f24f8-7e75-709b-b769-90f099f16e4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

