### PR TITLE
Migrate PR labeler to actions/labeler v6

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,26 +1,48 @@
-area:about:
-  - 'src/pages/about.astro'
-  - 'src/components/**/PhotoCarousel.*'
+"area:about":
+- changed-files:
+  - any-glob-to-any-file:
+    - src/pages/about.astro
+    - src/components/**/PhotoCarousel.*
 
-area:functions:
-  - 'functions/**'
+"area:functions":
+- changed-files:
+  - any-glob-to-any-file:
+    - functions/**
 
-area:tests-e2e:
-  - 'playwright/**'
-  - 'tests/playwright/**'
+"area:tests-e2e":
+- changed-files:
+  - any-glob-to-any-file:
+    - playwright/**
+    - tests/playwright/**
 
-area:tests-unit:
-  - 'tests/vitest/**'
+"area:tests-unit":
+- changed-files:
+  - any-glob-to-any-file:
+    - tests/vitest/**
 
-area:ci:
-  - '.github/workflows/**'
+"area:ci":
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/workflows/**
 
-area:content:
-  - 'src/content/**'
+"area:content":
+- changed-files:
+  - any-glob-to-any-file:
+    - src/content/**
 
-type:docs:
-  - '**/*.md'
+"type:docs":
+- changed-files:
+  - any-glob-to-any-file:
+    - "**/*.md"
 
-type:chore:
-  - 'scripts/**'
-  - '.github/**'
+"type:chore":
+- changed-files:
+  - any-glob-to-any-file:
+    - scripts/**
+    - .github/**
+
+"type:design":
+- changed-files:
+  - any-glob-to-any-file:
+    - src/styles/**
+    - src/pages/design/**

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,6 +12,13 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout labeler config from PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          sparse-checkout: .github/labeler.yml
+          sparse-checkout-cone-mode: false
+
       - name: Apply labels based on changed files
         uses: actions/labeler@v6
         with:


### PR DESCRIPTION
## Summary

Fixes the failing `label` check on all PRs by migrating `.github/labeler.yml` to the v6 schema and checking out PR-head config in the `pull_request_target` workflow.

## Why

`pull_request_target` runs the workflow from `main`, which still had the v4 flat-glob labeler format while the action is pinned to v6.

## Test plan

- [x] YAML matches actions/labeler v6 documented schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only labeler config and workflow checkout changes; no application runtime or security logic affected.
> 
> **Overview**
> Fixes failing PR label checks by aligning **`.github/labeler.yml`** with **actions/labeler v6** (`changed-files` / `any-glob-to-any-file` instead of flat glob lists) and adding a **`type:design`** rule for `src/styles/**` and `src/pages/design/**`.
> 
> The **`pull_request_target`** workflow now **sparse-checkouts** `.github/labeler.yml` at **`github.event.pull_request.head.sha`** before running the labeler, so PRs that update the config use their own v6 rules instead of whatever is on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1b95526959310c3e12acad949836f092a24dfd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request labeling configuration to a newer format.
  * Improved label application so PR labels are based on the latest configuration from the branch being reviewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->