### PR TITLE
Migrate PR labeler to actions/labeler v6 on development

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,26 +1,48 @@
-area:about:
-  - 'src/pages/about.astro'
-  - 'src/components/**/PhotoCarousel.*'
+"area:about":
+- changed-files:
+  - any-glob-to-any-file:
+    - src/pages/about.astro
+    - src/components/**/PhotoCarousel.*
 
-area:functions:
-  - 'functions/**'
+"area:functions":
+- changed-files:
+  - any-glob-to-any-file:
+    - functions/**
 
-area:tests-e2e:
-  - 'playwright/**'
-  - 'tests/playwright/**'
+"area:tests-e2e":
+- changed-files:
+  - any-glob-to-any-file:
+    - playwright/**
+    - tests/playwright/**
 
-area:tests-unit:
-  - 'tests/vitest/**'
+"area:tests-unit":
+- changed-files:
+  - any-glob-to-any-file:
+    - tests/vitest/**
 
-area:ci:
-  - '.github/workflows/**'
+"area:ci":
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/workflows/**
 
-area:content:
-  - 'src/content/**'
+"area:content":
+- changed-files:
+  - any-glob-to-any-file:
+    - src/content/**
 
-type:docs:
-  - '**/*.md'
+"type:docs":
+- changed-files:
+  - any-glob-to-any-file:
+    - "**/*.md"
 
-type:chore:
-  - 'scripts/**'
-  - '.github/**'
+"type:chore":
+- changed-files:
+  - any-glob-to-any-file:
+    - scripts/**
+    - .github/**
+
+"type:design":
+- changed-files:
+  - any-glob-to-any-file:
+    - src/styles/**
+    - src/pages/design/**

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,10 +12,18 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout labeler config from PR head
+      - name: Check if labeler config changed
+        id: labeler-config-changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          changed="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq 'map(.filename) | index(".github/labeler.yml") != null')"
+          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout labeler config
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.labeler-config-changed.outputs.changed == 'true' && github.event.pull_request.head.sha || github.event.pull_request.base.sha }}
           sparse-checkout: .github/labeler.yml
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,6 +12,13 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout labeler config from PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          sparse-checkout: .github/labeler.yml
+          sparse-checkout-cone-mode: false
+
       - name: Apply labels based on changed files
         uses: actions/labeler@v6
         with:


### PR DESCRIPTION
## Summary

Fixes the failing \`label\` check on PRs targeting \`development\` by migrating \`.github/labeler.yml\` to the actions/labeler v6 \`changed-files\` schema.

Also checks out the labeler config from the PR head in \`pr-labeler.yml\` so labeler runs correctly when PRs include config updates.

## Test plan

- [ ] Merge to \`development\`
- [ ] Re-run label check on #325 and other open PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only labeler configuration and workflow changes with no application runtime impact.
> 
> **Overview**
> Fixes failing PR label checks by updating **`.github/labeler.yml`** to the **actions/labeler v6** `changed-files` / `any-glob-to-any-file` format (replacing the old flat path lists).
> 
> The **`pr-labeler`** workflow now **sparse-checkouts** `.github/labeler.yml` from the **PR head** before running the labeler, so PRs that change the config are labeled with the updated rules. A new **`type:design`** label is added for `src/styles/**` and `src/pages/design/**`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9410a5bb9a85f093d66ee0ecb23f3244072032a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->