### PR TITLE
Phase 3: React mobile menu hook and nav visual baselines

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "test:e2e": "playwright test",
     "test:e2e:essential": "playwright test --grep=\"@essential\"",
     "test:e2e:essential:chromium": "playwright test --grep=\"@essential\" --project=chromium",
+    "test:e2e:visual:chromium": "playwright test tests/playwright/visual-smoke.spec.ts tests/playwright/component-visual-baselines.spec.ts --project=chromium",
+    "test:e2e:visual:update": "playwright test tests/playwright/visual-smoke.spec.ts tests/playwright/component-visual-baselines.spec.ts --project=chromium --update-snapshots",
     "test:e2e:ui": "playwright test --ui",
     "test:ci": "vitest run && playwright test",
     "test:ci:fast": "vitest run && corepack pnpm test:e2e:essential",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
     // Exhaustive device matrix (~6 min) — fixed and runnable via:
     // npx playwright test tests/playwright/mobile-navigation.spec.ts
     '**/mobile-navigation.spec.ts',
+    // Keep the visual gate small and maintainable. The Chromium-first smoke
+    // and component baseline suites cover the actively maintained snapshot path.
+    '**/visual-regression.spec.ts',
+    '**/visual-routes.spec.ts',
+    '**/visual-sectional.spec.ts',
+    '**/visual.spec.ts',
+    '**/visual/**/*.spec.ts',
     // Exclude slow visual regression tests - use essential visual tests
     // Exclude slow basic tests that timeout
     '**/basic.spec.ts', // Replace with optimized essential tests

--- a/src/components/islands/NavBarIsland.tsx
+++ b/src/components/islands/NavBarIsland.tsx
@@ -2,12 +2,13 @@
  * NavBarIsland - React island for site navigation
  *
  * Interactive navigation bar with mobile menu, logo, and responsive design.
- * Integrates ModernNavBar and MotionAccessibility for enhanced UX.
+ * Mobile menu state lives in useMobileMenu; theme toggle uses registerNavTheme.
  */
 import { useEffect, useRef, useState } from 'react';
 
 import type { NavLink } from '../../config/navLinks';
 import { normalizeNavPath } from '../../config/navLinks';
+import { useMobileMenu } from '../../features/nav/hooks/useMobileMenu';
 import { openCommandCenter } from '../../features/command-center/lib/commandEvents';
 import { registerModernNavBar } from '../../scripts/features/ModernNavBar';
 import { initMotionAccessibility } from '../../scripts/modules/MotionAccessibility';
@@ -40,6 +41,13 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
 
   const [activePath, setActivePath] = useState(() => normalizeNavPath(currentPath));
 
+  const { isOpen, burgerLabel, onBurgerClick, onBackdropClick, onMenuLinkClick } = useMobileMenu({
+    menu: mobileMenuRef,
+    backdrop: mobileBackdropRef,
+    burger: burgerButtonRef,
+    status: menuStatusRef,
+  });
+
   useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') {
       return;
@@ -54,11 +62,6 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
 
       const cleanupNav = registerModernNavBar({
         navBar: navRef.current,
-        navShell: shellRef.current,
-        mobileMenu: mobileMenuRef.current,
-        mobileBackdrop: mobileBackdropRef.current,
-        burgerButton: burgerButtonRef.current,
-        menuStatus: menuStatusRef.current,
         themeToggle: themeToggleRef.current,
       });
 
@@ -88,12 +91,17 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
     }
   }, []);
 
+  useEffect(() => {
+    const menu = mobileMenuRef.current;
+    if (menu) menu.inert = !isOpen;
+  }, [isOpen]);
+
   const isActive = (href: string): boolean => {
     if (!href.startsWith('/')) return false;
     return normalizeNavPath(href) === normalizeNavPath(activePath);
   };
 
-  const renderLink = (link: NavLink, className: string, keyPrefix: string) => {
+  const renderLink = (link: NavLink, className: string, keyPrefix: string, onNavigate?: () => void) => {
     const external = Boolean(link.external);
     const linkProps = external
       ? { target: link.target ?? '_blank', rel: 'noopener noreferrer' }
@@ -105,6 +113,7 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
           href={link.href}
           className={className}
           aria-current={!external && isActive(link.href) ? 'page' : undefined}
+          onClick={onNavigate}
           {...linkProps}
         >
           {link.label}
@@ -117,7 +126,7 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
     <div
       ref={shellRef}
       className="@container nav-shell relative overflow-visible sticky top-0 z-nav border-b border-border/40 bg-[color:var(--glass-surface-bg)] backdrop-blur supports-[backdrop-filter]:bg-[color:var(--glass-surface-bg-xl)]"
-      data-menu-state="closed"
+      data-menu-state={isOpen ? 'open' : 'closed'}
     >
       <div
         id="nav-menu-status"
@@ -237,10 +246,11 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
             id="nav-toggle"
             ref={burgerButtonRef}
             type="button"
-            className="nav-utility-button burger-menu-button md:hidden"
-            aria-label="Open navigation menu"
+            className={`nav-utility-button burger-menu-button md:hidden${isOpen ? ' active' : ''}`}
+            aria-label={burgerLabel}
             aria-controls="nav-mobile-links"
-            aria-expanded="false"
+            aria-expanded={isOpen}
+            onClick={onBurgerClick}
           >
             <span className="burger-icon" aria-hidden="true">
               <span className="burger-line" />
@@ -255,8 +265,9 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
         id="nav-mobile-backdrop"
         ref={mobileBackdropRef}
         className="mobile-menu-backdrop md:hidden"
-        data-state="closed"
-        aria-hidden="true"
+        data-state={isOpen ? 'open' : 'closed'}
+        aria-hidden={isOpen ? 'false' : 'true'}
+        onClick={onBackdropClick}
       />
 
       {/* No-JS mobile fallback — hidden once ModernNavBar sets data-js-nav on #navbar */}
@@ -276,12 +287,11 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
       <div
         ref={mobileMenuRef}
         id="nav-mobile-links"
-        className="mobile-menu border-t border-border bg-surface/98 shadow-lg md:hidden"
+        className={`mobile-menu border-t border-border bg-surface/98 shadow-lg md:hidden${isOpen ? ' active' : ''}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby="nav-mobile-menu-title"
-        data-state="closed"
-        inert
+        data-state={isOpen ? 'open' : 'closed'}
       >
         <div
           className="mobile-menu-content flex w-full flex-col gap-2 px-4 py-4 text-foreground @sm:gap-3 @sm:px-5 @sm:py-5"
@@ -296,6 +306,7 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
                 link,
                 'mobile-nav-link touch-target focus-ring-interactive flex min-h-11 items-center rounded-2xl px-3 py-3 text-sm font-semibold text-foreground/88 transition hover:bg-[color:var(--glass-surface-bg)] @sm:px-4 @sm:py-3 @sm:text-base',
                 'mobile',
+                onMenuLinkClick,
               ),
             )}
           </ul>

--- a/src/data/componentVisualBaselines.ts
+++ b/src/data/componentVisualBaselines.ts
@@ -5,8 +5,13 @@
 
 export type CommandCenterVisualSetup = 'browse' | 'results' | 'ask' | 'empty';
 
+export type NavVisualSetup = 'scrolled';
+
 export type ComponentVisualBaselineKey =
   | 'navbar'
+  | 'navbarMobileClosed'
+  | 'navbarMobileOpen'
+  | 'navbarScrolled'
   | 'footer'
   | 'searchOverlay'
   | 'commandCenterResults'
@@ -23,6 +28,12 @@ export type ComponentVisualBaseline = {
   tags: readonly string[];
   /** Optional Command Center state to capture */
   commandCenterSetup?: CommandCenterVisualSetup;
+  /** Override default desktop viewport (1280×800) */
+  viewport?: { width: number; height: number };
+  /** Open the mobile nav drawer before capture */
+  openMobileMenu?: boolean;
+  /** Scroll the page before capture */
+  navSetup?: NavVisualSetup;
 };
 
 export const componentVisualBaselines: Record<ComponentVisualBaselineKey, ComponentVisualBaseline> = {
@@ -33,6 +44,34 @@ export const componentVisualBaselines: Record<ComponentVisualBaselineKey, Compon
     description: 'Main site navigation (desktop layout)',
     snapshotFile: 'navbar.png',
     tags: ['@visual-essential', '@visual-components'],
+  },
+  navbarMobileClosed: {
+    key: 'navbarMobileClosed',
+    route: '/',
+    selector: 'header .nav-shell',
+    description: 'Mobile navigation bar (drawer closed)',
+    snapshotFile: 'navbarMobileClosed.png',
+    tags: ['@visual-essential', '@visual-components'],
+    viewport: { width: 390, height: 844 },
+  },
+  navbarMobileOpen: {
+    key: 'navbarMobileOpen',
+    route: '/',
+    selector: 'header .nav-shell',
+    description: 'Mobile navigation with drawer and backdrop open',
+    snapshotFile: 'navbarMobileOpen.png',
+    tags: ['@visual-essential', '@visual-components'],
+    viewport: { width: 390, height: 844 },
+    openMobileMenu: true,
+  },
+  navbarScrolled: {
+    key: 'navbarScrolled',
+    route: '/',
+    selector: 'header .nav-shell',
+    description: 'Desktop navigation after scroll (compact header)',
+    snapshotFile: 'navbarScrolled.png',
+    tags: ['@visual-essential', '@visual-components'],
+    navSetup: 'scrolled',
   },
   footer: {
     key: 'footer',

--- a/src/features/command-center/CommandCenter.tsx
+++ b/src/features/command-center/CommandCenter.tsx
@@ -39,6 +39,7 @@ export default function CommandCenter() {
   const panelRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const focusTrapRef = useRef<ReturnType<typeof createFocusTrap> | null>(null);
+  const scrollLockHeldRef = useRef(false);
 
   const flatItems = useMemo(() => flattenGroups(groups), [groups]);
   const hasResults = mode === 'find' && flatItems.length > 0;
@@ -128,13 +129,19 @@ export default function CommandCenter() {
 
   useEffect(() => {
     if (!isOpen) {
-      releaseScrollLock();
+      if (scrollLockHeldRef.current) {
+        releaseScrollLock();
+        scrollLockHeldRef.current = false;
+      }
       focusTrapRef.current?.deactivate();
       setActiveIndex(-1);
       return;
     }
 
-    acquireScrollLock();
+    if (!scrollLockHeldRef.current) {
+      acquireScrollLock();
+      scrollLockHeldRef.current = true;
+    }
 
     const toggleButton = document.getElementById('search-toggle');
     focusTrapRef.current = createFocusTrap(panelRef.current, {
@@ -148,7 +155,10 @@ export default function CommandCenter() {
 
     return () => {
       window.clearTimeout(timer);
-      releaseScrollLock();
+      if (scrollLockHeldRef.current) {
+        releaseScrollLock();
+        scrollLockHeldRef.current = false;
+      }
       focusTrapRef.current?.deactivate();
     };
   }, [isOpen]);

--- a/src/features/nav/hooks/useMobileMenu.ts
+++ b/src/features/nav/hooks/useMobileMenu.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+
+import {
+  closeSearch,
+  registerEscapeHandler,
+  registerMobileMenuClose,
+} from '../../../utils/headerController';
+import { createFocusTrap, type FocusTrap } from '../../../utils/focusTrap';
+import { acquireScrollLock, releaseScrollLock } from '../../../utils/scrollLock';
+
+export const MENU_LABEL_OPEN = 'Open navigation menu';
+export const MENU_LABEL_CLOSED = 'Close navigation menu';
+
+export type MobileMenuRefs = {
+  menu: RefObject<HTMLElement | null>;
+  backdrop: RefObject<HTMLElement | null>;
+  burger: RefObject<HTMLButtonElement | null>;
+  status: RefObject<HTMLElement | null>;
+};
+
+function getInitialMenuFocus(menu: HTMLElement): HTMLElement | null {
+  return menu.querySelector<HTMLElement>('.mobile-nav-link') ?? menu.querySelector<HTMLElement>('a[href]');
+}
+
+export function useMobileMenu(refs: MobileMenuRefs) {
+  const [isOpen, setIsOpen] = useState(false);
+  const focusTrapRef = useRef<FocusTrap | null>(null);
+  const isOpenRef = useRef(isOpen);
+
+  isOpenRef.current = isOpen;
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const open = useCallback(() => {
+    closeSearch();
+    setIsOpen(true);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    const menu = refs.menu.current;
+    const burger = refs.burger.current;
+    if (!menu || !burger) return;
+
+    if (!focusTrapRef.current) {
+      focusTrapRef.current = createFocusTrap(menu, {
+        initialFocus: getInitialMenuFocus(menu),
+        returnFocus: burger,
+        fallbackFocus: menu,
+      });
+    }
+
+    const trap = focusTrapRef.current;
+    const status = refs.status.current;
+
+    if (isOpen) {
+      acquireScrollLock();
+      trap.activate();
+      if (status) status.textContent = 'Navigation menu opened';
+    } else {
+      trap.deactivate();
+      releaseScrollLock();
+      if (status) status.textContent = 'Navigation menu closed';
+    }
+
+    return () => {
+      if (isOpenRef.current) {
+        trap.deactivate();
+        releaseScrollLock();
+      }
+    };
+  }, [isOpen, refs.menu, refs.burger, refs.status]);
+
+  useEffect(() => {
+    const unregisterClose = registerMobileMenuClose(() => {
+      if (isOpenRef.current) close();
+    });
+
+    const unregisterEscape = registerEscapeHandler({
+      id: 'mobile-menu',
+      priority: 1,
+      isActive: () => isOpenRef.current,
+      handle: () => close(),
+    });
+
+    return () => {
+      unregisterClose();
+      unregisterEscape();
+    };
+  }, [close]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const menu = refs.menu.current;
+    const burger = refs.burger.current;
+    const backdrop = refs.backdrop.current;
+    if (!menu || !burger) return;
+
+    const outsideClickHandler = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (menu.contains(target) || burger.contains(target) || backdrop?.contains(target)) {
+        return;
+      }
+      close();
+    };
+
+    document.addEventListener('click', outsideClickHandler);
+    return () => document.removeEventListener('click', outsideClickHandler);
+  }, [isOpen, close, refs.menu, refs.burger, refs.backdrop]);
+
+  const onBurgerClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      toggle();
+    },
+    [toggle],
+  );
+
+  const onBackdropClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      if (isOpenRef.current) close();
+    },
+    [close],
+  );
+
+  const onMenuLinkClick = useCallback(() => {
+    close();
+  }, [close]);
+
+  return {
+    isOpen,
+    open,
+    close,
+    toggle,
+    burgerLabel: isOpen ? MENU_LABEL_CLOSED : MENU_LABEL_OPEN,
+    onBurgerClick,
+    onBackdropClick,
+    onMenuLinkClick,
+  };
+}

--- a/src/features/nav/hooks/useMobileMenu.ts
+++ b/src/features/nav/hooks/useMobileMenu.ts
@@ -25,9 +25,16 @@ function getInitialMenuFocus(menu: HTMLElement): HTMLElement | null {
 export function useMobileMenu(refs: MobileMenuRefs) {
   const [isOpen, setIsOpen] = useState(false);
   const focusTrapRef = useRef<FocusTrap | null>(null);
+  const scrollLockHeldRef = useRef(false);
   const isOpenRef = useRef(isOpen);
 
   isOpenRef.current = isOpen;
+
+  const releaseMenuScrollLock = () => {
+    if (!scrollLockHeldRef.current) return;
+    releaseScrollLock();
+    scrollLockHeldRef.current = false;
+  };
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -59,20 +66,21 @@ export function useMobileMenu(refs: MobileMenuRefs) {
     const status = refs.status.current;
 
     if (isOpen) {
-      acquireScrollLock();
+      if (!scrollLockHeldRef.current) {
+        acquireScrollLock();
+        scrollLockHeldRef.current = true;
+      }
       trap.activate();
       if (status) status.textContent = 'Navigation menu opened';
     } else {
       trap.deactivate();
-      releaseScrollLock();
+      releaseMenuScrollLock();
       if (status) status.textContent = 'Navigation menu closed';
     }
 
     return () => {
-      if (isOpenRef.current) {
-        trap.deactivate();
-        releaseScrollLock();
-      }
+      trap.deactivate();
+      releaseMenuScrollLock();
     };
   }, [isOpen, refs.menu, refs.burger, refs.status]);
 

--- a/src/scripts/features/ModernNavBar.ts
+++ b/src/scripts/features/ModernNavBar.ts
@@ -4,35 +4,14 @@ type ElementHandle<T extends HTMLElement> =
   | undefined
   | { current: T | null | undefined };
 
-import {
-  applySystemTheme,
-  cycleThemePreference,
-  getThemePreference,
-  updateThemeToggleButton,
-  readThemePreference,
-} from '../../lib/theme';
-import {
-  closeSearch,
-  registerEscapeHandler,
-  registerMobileMenuClose,
-} from '../../utils/headerController';
-import { createFocusTrap, type FocusTrap } from '../../utils/focusTrap';
-import { acquireScrollLock, releaseScrollLock } from '../../utils/scrollLock';
+import { registerNavTheme } from './registerNavTheme';
 
 type ModernNavBarOptions = {
   navBar?: ElementHandle<HTMLElement>;
-  navShell?: ElementHandle<HTMLElement>;
-  mobileMenu?: ElementHandle<HTMLElement>;
-  mobileBackdrop?: ElementHandle<HTMLElement>;
-  burgerButton?: ElementHandle<HTMLButtonElement>;
-  menuStatus?: ElementHandle<HTMLElement>;
   themeToggle?: ElementHandle<HTMLButtonElement>;
 };
 
 type CleanupFn = () => void;
-
-const MENU_LABEL_OPEN = 'Open navigation menu';
-const MENU_LABEL_CLOSED = 'Close navigation menu';
 
 function resolveElement<T extends HTMLElement>(handle?: ElementHandle<T>): T | null {
   if (!handle) return null;
@@ -42,175 +21,15 @@ function resolveElement<T extends HTMLElement>(handle?: ElementHandle<T>): T | n
   return (handle as T) ?? null;
 }
 
-function cycleTheme(button: HTMLButtonElement | null) {
-  const nextPreference = cycleThemePreference();
-  updateThemeToggleButton(button, nextPreference);
-}
-
-function getInitialMenuFocus(menu: HTMLElement): HTMLElement | null {
-  return menu.querySelector<HTMLElement>('.mobile-nav-link') ?? menu.querySelector<HTMLElement>('a[href]');
-}
-
-function setMenuOpenState(
-  open: boolean,
-  menu: HTMLElement,
-  toggle: HTMLButtonElement,
-  backdrop: HTMLElement | null,
-  shell: HTMLElement | null,
-  status: HTMLElement | null,
-): void {
-  menu.dataset.state = open ? 'open' : 'closed';
-  menu.classList.toggle('active', open);
-  menu.inert = !open;
-
-  if (backdrop) {
-    backdrop.dataset.state = open ? 'open' : 'closed';
-    backdrop.setAttribute('aria-hidden', open ? 'false' : 'true');
-  }
-
-  if (shell) {
-    shell.dataset.menuState = open ? 'open' : 'closed';
-  }
-
-  toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-  toggle.classList.toggle('active', open);
-  toggle.setAttribute('aria-label', open ? MENU_LABEL_CLOSED : MENU_LABEL_OPEN);
-
-  if (status) {
-    status.textContent = open ? 'Navigation menu opened' : 'Navigation menu closed';
-  }
-}
-
-function openMobileMenu(
-  menu: HTMLElement,
-  toggle: HTMLButtonElement,
-  backdrop: HTMLElement | null,
-  shell: HTMLElement | null,
-  status: HTMLElement | null,
-  focusTrap: FocusTrap,
-): void {
-  closeSearch();
-  setMenuOpenState(true, menu, toggle, backdrop, shell, status);
-  acquireScrollLock();
-  focusTrap.activate();
-}
-
-function closeMobileMenu(
-  menu: HTMLElement,
-  toggle: HTMLButtonElement,
-  backdrop: HTMLElement | null,
-  shell: HTMLElement | null,
-  status: HTMLElement | null,
-  focusTrap: FocusTrap,
-): void {
-  setMenuOpenState(false, menu, toggle, backdrop, shell, status);
-  focusTrap.deactivate();
-  releaseScrollLock();
-}
-
+/** Theme toggle wiring for the nav bar. Mobile menu is handled by `useMobileMenu` in NavBarIsland. */
 export function registerModernNavBar(options: ModernNavBarOptions): CleanupFn {
   const navBar = resolveElement(options.navBar);
-  const navShell = resolveElement(options.navShell);
-  const mobileMenu = resolveElement(options.mobileMenu);
-  const mobileBackdrop = resolveElement(options.mobileBackdrop);
-  const burgerButton = resolveElement(options.burgerButton);
-  const menuStatus = resolveElement(options.menuStatus);
-  const themeToggle = resolveElement(options.themeToggle);
-
-  const cleanupFns: CleanupFn[] = [];
-
-  if (themeToggle) {
-    updateThemeToggleButton(themeToggle, getThemePreference());
-    const handler = (event: Event) => {
-      event.preventDefault();
-      cycleTheme(themeToggle);
-    };
-    themeToggle.addEventListener('click', handler);
-    cleanupFns.push(() => themeToggle.removeEventListener('click', handler));
-
-    const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
-    const systemThemeListener = (event: MediaQueryListEvent) => {
-      if (readThemePreference() !== 'system') return;
-      const inferredTheme = event.matches ? 'dark' : 'light';
-      applySystemTheme(inferredTheme);
-      updateThemeToggleButton(themeToggle, 'system');
-    };
-
-    if (mediaQuery?.addEventListener) {
-      mediaQuery.addEventListener('change', systemThemeListener);
-      cleanupFns.push(() => mediaQuery.removeEventListener('change', systemThemeListener));
-    }
-  }
-
-  if (burgerButton && mobileMenu) {
-    const focusTrap = createFocusTrap(mobileMenu, {
-      initialFocus: getInitialMenuFocus(mobileMenu),
-      returnFocus: burgerButton,
-      fallbackFocus: mobileMenu,
-    });
-
-    const close = () =>
-      closeMobileMenu(mobileMenu, burgerButton, mobileBackdrop, navShell, menuStatus, focusTrap);
-    const open = () =>
-      openMobileMenu(mobileMenu, burgerButton, mobileBackdrop, navShell, menuStatus, focusTrap);
-
-    const toggleHandler = (event: Event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      if (mobileMenu.classList.contains('active')) {
-        close();
-      } else {
-        open();
-      }
-    };
-
-    burgerButton.addEventListener('click', toggleHandler);
-    cleanupFns.push(() => burgerButton.removeEventListener('click', toggleHandler));
-
-    if (mobileBackdrop) {
-      const backdropHandler = (event: Event) => {
-        event.preventDefault();
-        if (mobileMenu.classList.contains('active')) close();
-      };
-      mobileBackdrop.addEventListener('click', backdropHandler);
-      cleanupFns.push(() => mobileBackdrop.removeEventListener('click', backdropHandler));
-    }
-
-    cleanupFns.push(
-      registerMobileMenuClose(() => {
-        if (mobileMenu.classList.contains('active')) close();
-      }),
-    );
-
-    cleanupFns.push(
-      registerEscapeHandler({
-        id: 'mobile-menu',
-        priority: 1,
-        isActive: () => mobileMenu.classList.contains('active'),
-        handle: () => close(),
-      }),
-    );
-
-    const outsideClickHandler = (event: MouseEvent) => {
-      if (!mobileMenu.classList.contains('active')) return;
-      const target = event.target as Node;
-      if (
-        mobileMenu.contains(target) ||
-        burgerButton.contains(target) ||
-        mobileBackdrop?.contains(target)
-      ) {
-        return;
-      }
-      close();
-    };
-    document.addEventListener('click', outsideClickHandler);
-    cleanupFns.push(() => document.removeEventListener('click', outsideClickHandler));
-  }
+  const cleanupTheme = registerNavTheme({ themeToggle: options.themeToggle });
 
   navBar?.setAttribute('data-js-nav', 'true');
 
   return () => {
-    cleanupFns.forEach((fn) => fn());
+    cleanupTheme();
   };
 }
 
@@ -220,20 +39,10 @@ export function initModernNavBar(): CleanupFn | undefined {
     return undefined;
   }
 
-  const navShell = navBar.closest('.nav-shell');
-  const mobileMenu = document.getElementById('nav-mobile-links');
-  const mobileBackdrop = document.getElementById('nav-mobile-backdrop');
-  const burgerButton = document.getElementById('nav-toggle') as HTMLButtonElement | null;
-  const menuStatus = document.getElementById('nav-menu-status');
   const themeToggle = document.getElementById('theme-toggle') as HTMLButtonElement | null;
 
   return registerModernNavBar({
     navBar,
-    navShell: navShell instanceof HTMLElement ? navShell : null,
-    mobileMenu,
-    mobileBackdrop,
-    burgerButton,
-    menuStatus,
     themeToggle,
   });
 }

--- a/src/scripts/features/index.ts
+++ b/src/scripts/features/index.ts
@@ -1,2 +1,3 @@
 // Feature Scripts - UI features and interactions
 export { registerModernNavBar } from './ModernNavBar';
+export { registerNavTheme } from './registerNavTheme';

--- a/src/scripts/features/registerNavTheme.ts
+++ b/src/scripts/features/registerNavTheme.ts
@@ -1,0 +1,67 @@
+import {
+  applySystemTheme,
+  cycleThemePreference,
+  getThemePreference,
+  updateThemeToggleButton,
+  readThemePreference,
+} from '../../lib/theme';
+
+type ElementHandle<T extends HTMLElement> =
+  | T
+  | null
+  | undefined
+  | { current: T | null | undefined };
+
+type NavThemeOptions = {
+  themeToggle?: ElementHandle<HTMLButtonElement>;
+};
+
+type CleanupFn = () => void;
+
+function resolveElement<T extends HTMLElement>(handle?: ElementHandle<T>): T | null {
+  if (!handle) return null;
+  if (typeof (handle as { current?: T | null }).current !== 'undefined') {
+    return (handle as { current?: T | null }).current ?? null;
+  }
+  return (handle as T) ?? null;
+}
+
+function cycleTheme(button: HTMLButtonElement | null) {
+  const nextPreference = cycleThemePreference();
+  updateThemeToggleButton(button, nextPreference);
+}
+
+export function registerNavTheme(options: NavThemeOptions): CleanupFn {
+  const themeToggle = resolveElement(options.themeToggle);
+  const cleanupFns: CleanupFn[] = [];
+
+  if (!themeToggle) {
+    return () => undefined;
+  }
+
+  updateThemeToggleButton(themeToggle, getThemePreference());
+
+  const handler = (event: Event) => {
+    event.preventDefault();
+    cycleTheme(themeToggle);
+  };
+  themeToggle.addEventListener('click', handler);
+  cleanupFns.push(() => themeToggle.removeEventListener('click', handler));
+
+  const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+  const systemThemeListener = (event: MediaQueryListEvent) => {
+    if (readThemePreference() !== 'system') return;
+    const inferredTheme = event.matches ? 'dark' : 'light';
+    applySystemTheme(inferredTheme);
+    updateThemeToggleButton(themeToggle, 'system');
+  };
+
+  if (mediaQuery?.addEventListener) {
+    mediaQuery.addEventListener('change', systemThemeListener);
+    cleanupFns.push(() => mediaQuery.removeEventListener('change', systemThemeListener));
+  }
+
+  return () => {
+    cleanupFns.forEach((fn) => fn());
+  };
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -124,6 +124,11 @@
     display: none;
   }
 
+  /* Keep sticky header aligned when scroll lock removes the scrollbar gutter */
+  body.scroll-locked .nav-shell {
+    padding-right: var(--scrollbar-width, 0px);
+  }
+
   /* Burger → close icon animation */
   .burger-icon {
     display: flex;

--- a/src/utils/scrollLock.ts
+++ b/src/utils/scrollLock.ts
@@ -4,18 +4,54 @@
  * scroll is restored only when every holder has released.
  */
 
+const SCROLL_LOCK_CLASS = 'scroll-locked';
+
 let lockCount = 0;
 let savedScrollY = 0;
+
+function getScrollbarWidth(): number {
+  return Math.max(0, window.innerWidth - document.documentElement.clientWidth);
+}
+
+function applyScrollLockStyles(): void {
+  savedScrollY = window.scrollY;
+  const scrollbarWidth = getScrollbarWidth();
+
+  document.documentElement.style.overflow = 'hidden';
+  document.body.style.overflow = 'hidden';
+  document.body.style.position = 'fixed';
+  document.body.style.top = `-${savedScrollY}px`;
+  document.body.style.left = '0';
+  document.body.style.right = '0';
+  document.body.style.width = 'auto';
+
+  if (scrollbarWidth > 0) {
+    document.body.style.paddingRight = `${scrollbarWidth}px`;
+    document.documentElement.style.setProperty('--scrollbar-width', `${scrollbarWidth}px`);
+  }
+
+  document.body.classList.add(SCROLL_LOCK_CLASS);
+}
+
+function clearScrollLockStyles(): void {
+  document.documentElement.style.overflow = '';
+  document.body.style.overflow = '';
+  document.body.style.position = '';
+  document.body.style.top = '';
+  document.body.style.left = '';
+  document.body.style.right = '';
+  document.body.style.width = '';
+  document.body.style.paddingRight = '';
+  document.documentElement.style.removeProperty('--scrollbar-width');
+  document.body.classList.remove(SCROLL_LOCK_CLASS);
+  window.scrollTo(0, savedScrollY);
+}
 
 export function acquireScrollLock(): void {
   if (typeof document === 'undefined') return;
 
   if (lockCount === 0) {
-    savedScrollY = window.scrollY;
-    document.body.style.overflow = 'hidden';
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${savedScrollY}px`;
-    document.body.style.width = '100%';
+    applyScrollLockStyles();
   }
   lockCount += 1;
 }
@@ -27,11 +63,7 @@ export function releaseScrollLock(): void {
   lockCount -= 1;
   if (lockCount > 0) return;
 
-  document.body.style.overflow = '';
-  document.body.style.position = '';
-  document.body.style.top = '';
-  document.body.style.width = '';
-  window.scrollTo(0, savedScrollY);
+  clearScrollLockStyles();
 }
 
 export function isScrollLocked(): boolean {
@@ -42,9 +74,6 @@ export function resetScrollLockForTests(): void {
   lockCount = 0;
   savedScrollY = 0;
   if (typeof document !== 'undefined') {
-    document.body.style.overflow = '';
-    document.body.style.position = '';
-    document.body.style.top = '';
-    document.body.style.width = '';
+    clearScrollLockStyles();
   }
 }

--- a/tests/playwright/component-visual-baselines.spec.ts
+++ b/tests/playwright/component-visual-baselines.spec.ts
@@ -1,19 +1,96 @@
-import { test, expect } from './fixtures';
+import { test, expect, type Page } from './fixtures';
+import { preparePage } from './visual/_visualHelper';
+import {
+  componentVisualBaselines,
+  type ComponentVisualBaselineKey,
+} from '../../src/data/componentVisualBaselines';
 
 // Visual baselines for critical components
-// Tags: @visual @components
+// Tags: @visual @visual-components
 
-async function capture(page, route, name) {
+const NAV_BASELINE_KEYS = [
+  'navbar',
+  'navbarMobileClosed',
+  'navbarMobileOpen',
+  'navbarScrolled',
+] as const satisfies readonly ComponentVisualBaselineKey[];
+
+async function capturePreview(page: Page, route: string, name: string) {
   await page.goto(route);
-  await page.waitForLoadState('domcontentloaded');
-  await expect(page).toHaveScreenshot(`${name}.png`, { fullPage: false });
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.waitForLoadState('load');
+  await page.evaluate(async () => {
+    try {
+      if (document.fonts && 'ready' in document.fonts) {
+        await document.fonts.ready;
+      }
+    } catch {
+      /* noop */
+    }
+  });
+  await expect(page).toHaveScreenshot(`${name}.png`, {
+    fullPage: false,
+    animations: 'disabled',
+    maxDiffPixelRatio: 0.005,
+  });
 }
 
-test.describe('Component Visual Baselines', () => {
-  test('nav', async ({ page }) => {
-    await capture(page, '/components/nav-preview', 'nav');
+async function setupNavVisual(page: Page, cfg: (typeof componentVisualBaselines)[ComponentVisualBaselineKey]) {
+  await page.waitForFunction(() => (window as Window & { __navHydrated?: boolean }).__navHydrated === true, {
+    timeout: 10000,
   });
-  test('project card', async ({ page }) => {
-    await capture(page, '/components/project-card-preview', 'project-card');
+
+  if (cfg.navSetup === 'scrolled') {
+    await page.evaluate(() => window.scrollTo(0, 120));
+    await page.waitForFunction(() => document.querySelector('.nav-shell--scrolled') !== null, { timeout: 5000 });
+  }
+
+  if (cfg.openMobileMenu) {
+    await page.locator('#nav-toggle').click();
+    await expect(page.locator('#nav-mobile-links')).toHaveClass(/active/);
+    await expect(page.locator('#nav-mobile-backdrop')).toHaveAttribute('data-state', 'open');
+  }
+}
+
+test.describe('Component Visual Baselines @visual @visual-components', () => {
+  test('nav preview', async ({ page }) => {
+    await capturePreview(page, '/components/nav-preview', 'nav');
   });
+
+  test('project card preview', async ({ page }) => {
+    await capturePreview(page, '/components/project-card-preview', 'project-card');
+  });
+
+  for (const key of NAV_BASELINE_KEYS) {
+    const cfg = componentVisualBaselines[key];
+
+    test(`production ${cfg.key}`, async ({ page }) => {
+      await preparePage(page);
+      if (cfg.viewport) {
+        await page.setViewportSize(cfg.viewport);
+      }
+      await page.goto(cfg.route, { waitUntil: 'networkidle' });
+      await setupNavVisual(page, cfg);
+
+      const element = page.locator(cfg.selector).first();
+      await expect(element).toBeVisible();
+
+      await element.evaluate((el) => {
+        try {
+          el.style.boxSizing = 'border-box';
+          const rect = el.getBoundingClientRect();
+          el.style.height = `${Math.round(rect.height)}px`;
+        } catch {
+          /* noop */
+        }
+      });
+
+      await expect(element).toHaveScreenshot(cfg.snapshotFile, {
+        animations: 'disabled',
+        maxDiffPixelRatio: 0.02,
+        scale: 'css',
+        threshold: 0.01,
+      });
+    });
+  }
 });

--- a/tests/playwright/layout-scroll-lock.spec.ts
+++ b/tests/playwright/layout-scroll-lock.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+async function readLayout(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const body = document.body;
+    const html = document.documentElement;
+    const main = document.querySelector('main');
+    return {
+      bodyPosition: getComputedStyle(body).position,
+      bodyTop: body.style.top,
+      bodyInlineWidth: body.style.width,
+      bodyPaddingRight: body.style.paddingRight,
+      scrollWidth: html.scrollWidth,
+      clientWidth: html.clientWidth,
+      innerWidth: window.innerWidth,
+      mainLeft: main?.getBoundingClientRect().left ?? null,
+      mainWidth: main?.getBoundingClientRect().width ?? null,
+    };
+  });
+}
+
+test.describe('Page layout after overlays @essential', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+    await page.waitForFunction(() => (window as Window & { __navHydrated?: boolean }).__navHydrated === true, {
+      timeout: 10000,
+    });
+  });
+
+  test('mobile menu does not leave body fixed or horizontally shifted', async ({ page }) => {
+    const before = await readLayout(page);
+    expect(before.bodyPosition).toBe('static');
+    expect(before.scrollWidth).toBeLessThanOrEqual(before.clientWidth + 1);
+
+    await page.locator('#nav-toggle').click();
+    const open = await readLayout(page);
+    expect(open.bodyPosition).toBe('fixed');
+
+    await page.locator('#nav-toggle').click();
+    const after = await readLayout(page);
+    expect(after.bodyPosition).toBe('static');
+    expect(after.bodyTop).toBe('');
+    expect(after.bodyInlineWidth).toBe('');
+    expect(after.scrollWidth).toBeLessThanOrEqual(after.clientWidth + 1);
+    expect(after.mainLeft).toBe(0);
+    expect(after.mainWidth).toBeCloseTo(390, 0);
+  });
+
+  test('command center does not leave body fixed after close', async ({ page }) => {
+    await page.locator('#search-toggle').click();
+    await page.locator('#search-overlay').waitFor({ state: 'attached', timeout: 10000 });
+
+    const open = await readLayout(page);
+    expect(open.bodyPosition).toBe('fixed');
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#search-overlay')).toHaveAttribute('data-state', 'closed');
+
+    const after = await readLayout(page);
+    expect(after.bodyPosition).toBe('static');
+    expect(after.scrollWidth).toBeLessThanOrEqual(after.clientWidth + 1);
+    expect(after.mainLeft).toBe(0);
+  });
+
+  test('opening search while menu is open keeps a single scroll lock owner', async ({ page }) => {
+    await page.locator('#nav-toggle').click();
+    await expect(page.locator('#nav-mobile-links')).toHaveClass(/active/);
+
+    await page.locator('#search-toggle').click();
+    await expect(page.locator('#nav-mobile-links')).not.toHaveClass(/active/);
+    await page.locator('#search-overlay').waitFor({ state: 'attached', timeout: 10000 });
+
+    const duringSearch = await readLayout(page);
+    expect(duringSearch.bodyPosition).toBe('fixed');
+
+    await page.keyboard.press('Escape');
+
+    const after = await readLayout(page);
+    expect(after.bodyPosition).toBe('static');
+    expect(after.mainLeft).toBe(0);
+  });
+});

--- a/tests/playwright/visual-smoke.spec.ts
+++ b/tests/playwright/visual-smoke.spec.ts
@@ -7,22 +7,40 @@ import { waitForLayoutStability } from './utils/deterministic-waits';
 const routes = [
   { path: '/', name: 'home' },
   { path: '/about', name: 'about' },
-  { path: '/projects', name: 'projects' }
+  { path: '/projects', name: 'projects' },
+  { path: '/contact', name: 'contact' }
 ];
 
 for (const r of routes) {
   test(`visual smoke: ${r.name} @visual-smoke`, async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto(r.path);
-    // Wait for primary content landmark to exist
     await page.waitForSelector('main');
+    await page.evaluate(async () => {
+      try {
+        if (document.fonts && 'ready' in document.fonts) {
+          await document.fonts.ready;
+        }
+      } catch {
+        /* noop */
+      }
+    });
     await waitForLayoutStability(page);
     
     // Basic smoke test: ensure page has expected content structure
     await expect(page.locator('main')).toBeVisible();
     await expect(page.locator('h1')).toBeVisible();
-    
-    // Skip visual snapshot comparison for now to avoid platform-specific issues
-    // const screenshot = await page.screenshot();
-    // expect(screenshot).toMatchSnapshot(`${r.name}-smoke.png`, { maxDiffPixelRatio: 0.02 });
+
+    await expect(page).toHaveScreenshot(`${r.name}.png`, {
+      fullPage: false,
+      animations: 'disabled',
+      maxDiffPixelRatio: r.name === 'contact' ? 0.015 : 0.01,
+      mask: [
+        page.locator('.photo-carousel'),
+        page.locator('[name="cf-turnstile-response"]'),
+        page.locator('#turnstile-container iframe'),
+        page.locator('time'),
+      ],
+    });
   });
 }

--- a/tests/playwright/visual/component-visual.spec.ts
+++ b/tests/playwright/visual/component-visual.spec.ts
@@ -60,6 +60,23 @@ async function setupCommandCenter(page: Page, setup: CommandCenterVisualSetup) {
   });
 }
 
+async function setupNavVisual(page: Page, cfg: (typeof componentVisualBaselines)[keyof typeof componentVisualBaselines]) {
+  await page.waitForFunction(() => (window as Window & { __navHydrated?: boolean }).__navHydrated === true, {
+    timeout: 10000,
+  });
+
+  if (cfg.navSetup === 'scrolled') {
+    await page.evaluate(() => window.scrollTo(0, 120));
+    await page.waitForFunction(() => document.querySelector('.nav-shell--scrolled') !== null, { timeout: 5000 });
+  }
+
+  if (cfg.openMobileMenu) {
+    await page.locator('#nav-toggle').click();
+    await expect(page.locator('#nav-mobile-links')).toHaveClass(/active/);
+    await expect(page.locator('#nav-mobile-backdrop')).toHaveAttribute('data-state', 'open');
+  }
+}
+
 // Component-level focused snapshots (smaller surface, faster diff isolation)
 // Tags: @visual-essential @visual-components
 // Registry: src/data/componentVisualBaselines.ts (linked from componentDocs.ts)
@@ -68,10 +85,16 @@ test.describe('@visual-essential @visual-components Component Visual Snapshots',
   for (const cfg of Object.values(componentVisualBaselines)) {
     test(`component visual ${cfg.key}`, async ({ page }) => {
       await preparePage(page);
+      if (cfg.viewport) {
+        await page.setViewportSize(cfg.viewport);
+      }
       await page.goto(cfg.route, { waitUntil: 'networkidle' });
 
       if (cfg.commandCenterSetup) {
         await setupCommandCenter(page, cfg.commandCenterSetup);
+      } else if (cfg.openMobileMenu || cfg.navSetup || cfg.selector.includes('.nav-shell')) {
+        await setupNavVisual(page, cfg);
+        await expect(page.locator(cfg.selector).first()).toBeVisible();
       } else {
         await expect(page.locator(cfg.selector).first()).toBeVisible();
       }

--- a/tests/playwright/visual/config.ts
+++ b/tests/playwright/visual/config.ts
@@ -5,13 +5,13 @@ export type DiffCfg = { maxDiffPixelRatio?: number; maxDiffPixels?: number };
 export type RouteCfg = { mask?: string[]; diff?: DiffCfg; fullPage?: boolean };
 
 export const VISUAL_ROUTE_CONFIG: Record<string, RouteCfg> = {
-  '/': { diff: { maxDiffPixelRatio: 0.01 } },
-  '/projects/': { diff: { maxDiffPixelRatio: 0.01 } },
-  '/blog/': { diff: { maxDiffPixelRatio: 0.02 } },
-  '/about/': { mask: ['.photo-carousel'], diff: { maxDiffPixelRatio: 0.025 } },
+  '/': { diff: { maxDiffPixelRatio: 0.008 } },
+  '/projects/': { diff: { maxDiffPixelRatio: 0.008 } },
+  '/blog/': { diff: { maxDiffPixelRatio: 0.012 } },
+  '/about/': { mask: ['.photo-carousel'], diff: { maxDiffPixelRatio: 0.015 } },
   '/contact/': {
-    mask: ['#hero .absolute', '#contact-info .absolute', '.coin-flip'],
-    diff: { maxDiffPixelRatio: 0.02 },
+    mask: ['[name="cf-turnstile-response"]', '#turnstile-container iframe'],
+    diff: { maxDiffPixelRatio: 0.015 },
     fullPage: false,
   },
 };

--- a/tests/vitest/ModernNavBar.test.ts
+++ b/tests/vitest/ModernNavBar.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { registerModernNavBar } from '../../src/scripts/features/ModernNavBar';
-import { resetHeaderControllerForTests } from '../../src/utils/headerController';
-import { resetScrollLockForTests } from '../../src/utils/scrollLock';
 
 vi.mock('../../src/lib/theme', () => ({
   applySystemTheme: vi.fn(),
@@ -12,35 +10,16 @@ vi.mock('../../src/lib/theme', () => ({
   readThemePreference: vi.fn(() => 'system'),
 }));
 
-vi.mock('../../src/utils/headerController', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../src/utils/headerController')>();
-  return {
-    ...actual,
-    closeSearch: vi.fn(),
-  };
-});
-
 function mountNavDom() {
   document.body.innerHTML = `
-    <div class="nav-shell" data-menu-state="closed">
-      <div id="nav-menu-status" class="sr-only" aria-live="polite"></div>
-      <nav id="navbar">
-        <button id="nav-toggle" type="button" aria-expanded="false" aria-label="Open navigation menu">Menu</button>
-      </nav>
-      <div id="nav-mobile-backdrop" class="mobile-menu-backdrop" data-state="closed" aria-hidden="true"></div>
-      <div id="nav-mobile-links" class="mobile-menu" data-state="closed" inert role="dialog">
-        <a href="/about/" class="mobile-nav-link">About</a>
-      </div>
-    </div>
+    <nav id="navbar">
+      <button id="theme-toggle" type="button">Theme</button>
+    </nav>
   `;
 
   return {
-    shell: document.querySelector('.nav-shell') as HTMLElement,
     nav: document.getElementById('navbar') as HTMLElement,
-    menu: document.getElementById('nav-mobile-links') as HTMLElement,
-    backdrop: document.getElementById('nav-mobile-backdrop') as HTMLElement,
-    burger: document.getElementById('nav-toggle') as HTMLButtonElement,
-    status: document.getElementById('nav-menu-status') as HTMLElement,
+    themeToggle: document.getElementById('theme-toggle') as HTMLButtonElement,
   };
 }
 
@@ -48,8 +27,6 @@ describe('ModernNavBar', () => {
   let cleanup: (() => void) | undefined;
 
   beforeEach(() => {
-    resetHeaderControllerForTests();
-    resetScrollLockForTests();
     document.body.style.cssText = '';
   });
 
@@ -57,90 +34,28 @@ describe('ModernNavBar', () => {
     cleanup?.();
     cleanup = undefined;
     document.body.innerHTML = '';
-    resetHeaderControllerForTests();
-    resetScrollLockForTests();
-  });
-
-  it('opens the mobile menu with backdrop and updated burger label', () => {
-    const { nav, menu, backdrop, burger, shell, status } = mountNavDom();
-
-    cleanup = registerModernNavBar({
-      navBar: nav,
-      navShell: shell,
-      mobileMenu: menu,
-      mobileBackdrop: backdrop,
-      burgerButton: burger,
-      menuStatus: status,
-    });
-
-    burger.click();
-
-    expect(menu.classList.contains('active')).toBe(true);
-    expect(menu.dataset.state).toBe('open');
-    expect(menu.inert).toBe(false);
-    expect(backdrop.dataset.state).toBe('open');
-    expect(backdrop.getAttribute('aria-hidden')).toBe('false');
-    expect(shell.dataset.menuState).toBe('open');
-    expect(burger.getAttribute('aria-expanded')).toBe('true');
-    expect(burger.getAttribute('aria-label')).toBe('Close navigation menu');
-    expect(status.textContent).toBe('Navigation menu opened');
-  });
-
-  it('closes the mobile menu when the burger is toggled again', () => {
-    const { nav, menu, backdrop, burger, shell, status } = mountNavDom();
-
-    cleanup = registerModernNavBar({
-      navBar: nav,
-      navShell: shell,
-      mobileMenu: menu,
-      mobileBackdrop: backdrop,
-      burgerButton: burger,
-      menuStatus: status,
-    });
-
-    burger.click();
-    burger.click();
-
-    expect(menu.classList.contains('active')).toBe(false);
-    expect(menu.dataset.state).toBe('closed');
-    expect(menu.inert).toBe(true);
-    expect(backdrop.dataset.state).toBe('closed');
-    expect(shell.dataset.menuState).toBe('closed');
-    expect(burger.getAttribute('aria-expanded')).toBe('false');
-    expect(burger.getAttribute('aria-label')).toBe('Open navigation menu');
-    expect(status.textContent).toBe('Navigation menu closed');
-  });
-
-  it('closes the mobile menu when the backdrop is clicked', () => {
-    const { nav, menu, backdrop, burger, shell, status } = mountNavDom();
-
-    cleanup = registerModernNavBar({
-      navBar: nav,
-      navShell: shell,
-      mobileMenu: menu,
-      mobileBackdrop: backdrop,
-      burgerButton: burger,
-      menuStatus: status,
-    });
-
-    burger.click();
-    backdrop.click();
-
-    expect(menu.classList.contains('active')).toBe(false);
-    expect(menu.dataset.state).toBe('closed');
   });
 
   it('marks the navbar as JS-enhanced', () => {
-    const { nav, menu, backdrop, burger, shell } = mountNavDom();
+    const { nav, themeToggle } = mountNavDom();
 
     cleanup = registerModernNavBar({
       navBar: nav,
-      navShell: shell,
-      mobileMenu: menu,
-      mobileBackdrop: backdrop,
-      burgerButton: burger,
+      themeToggle,
     });
 
     expect(nav.getAttribute('data-js-nav')).toBe('true');
+  });
+
+  it('initializes the theme toggle button', async () => {
+    const { updateThemeToggleButton } = await import('../../src/lib/theme');
+    const { nav, themeToggle } = mountNavDom();
+
+    cleanup = registerModernNavBar({
+      navBar: nav,
+      themeToggle,
+    });
+
+    expect(updateThemeToggleButton).toHaveBeenCalledWith(themeToggle, 'system');
   });
 });

--- a/tests/vitest/scrollLock.test.ts
+++ b/tests/vitest/scrollLock.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { acquireScrollLock, releaseScrollLock, isScrollLocked, resetScrollLockForTests } from '../../src/utils/scrollLock';
+import {
+  acquireScrollLock,
+  releaseScrollLock,
+  isScrollLocked,
+  resetScrollLockForTests,
+} from '../../src/utils/scrollLock';
 
 describe('scrollLock', () => {
   beforeEach(() => {
     resetScrollLockForTests();
     document.body.style.cssText = '';
+    document.documentElement.style.cssText = '';
+    document.body.className = '';
   });
 
   afterEach(() => {
@@ -16,6 +23,7 @@ describe('scrollLock', () => {
     expect(isScrollLocked()).toBe(true);
     expect(document.body.style.overflow).toBe('hidden');
     expect(document.body.style.position).toBe('fixed');
+    expect(document.body.classList.contains('scroll-locked')).toBe(true);
   });
 
   it('keeps lock until all holders release', () => {
@@ -26,5 +34,19 @@ describe('scrollLock', () => {
     releaseScrollLock();
     expect(isScrollLocked()).toBe(false);
     expect(document.body.style.overflow).toBe('');
+    expect(document.body.classList.contains('scroll-locked')).toBe(false);
+  });
+
+  it('ignores release when no lock is held', () => {
+    releaseScrollLock();
+    expect(isScrollLocked()).toBe(false);
+    expect(document.body.style.position).toBe('');
+  });
+
+  it('uses left/right anchoring instead of width 100%', () => {
+    acquireScrollLock();
+    expect(document.body.style.left).toBe('0px');
+    expect(document.body.style.right).toBe('0px');
+    expect(document.body.style.width).toBe('auto');
   });
 });

--- a/tests/vitest/useMobileMenu.test.tsx
+++ b/tests/vitest/useMobileMenu.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+
+import { useMobileMenu } from '../../src/features/nav/hooks/useMobileMenu';
+import { resetHeaderControllerForTests } from '../../src/utils/headerController';
+import { resetScrollLockForTests } from '../../src/utils/scrollLock';
+
+vi.mock('../../src/utils/headerController', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/utils/headerController')>();
+  return {
+    ...actual,
+    closeSearch: vi.fn(),
+  };
+});
+
+function MobileMenuFixture() {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const burgerRef = useRef<HTMLButtonElement>(null);
+  const statusRef = useRef<HTMLDivElement>(null);
+
+  const { isOpen, burgerLabel, onBurgerClick, onBackdropClick } = useMobileMenu({
+    menu: menuRef,
+    backdrop: backdropRef,
+    burger: burgerRef,
+    status: statusRef,
+  });
+
+  return (
+    <div className="nav-shell" data-menu-state={isOpen ? 'open' : 'closed'}>
+      <div ref={statusRef} id="nav-menu-status" />
+      <button
+        ref={burgerRef}
+        id="nav-toggle"
+        type="button"
+        aria-expanded={isOpen}
+        aria-label={burgerLabel}
+        onClick={onBurgerClick}
+      >
+        Menu
+      </button>
+      <div
+        ref={backdropRef}
+        id="nav-mobile-backdrop"
+        data-state={isOpen ? 'open' : 'closed'}
+        aria-hidden={isOpen ? 'false' : 'true'}
+        onClick={onBackdropClick}
+      />
+      <div
+        ref={menuRef}
+        id="nav-mobile-links"
+        data-state={isOpen ? 'open' : 'closed'}
+        className={isOpen ? 'active' : ''}
+      >
+        <a href="/about/" className="mobile-nav-link">
+          About
+        </a>
+      </div>
+    </div>
+  );
+}
+
+describe('useMobileMenu', () => {
+  beforeEach(() => {
+    resetHeaderControllerForTests();
+    resetScrollLockForTests();
+    document.body.style.cssText = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    resetHeaderControllerForTests();
+    resetScrollLockForTests();
+  });
+
+  it('opens the mobile menu with backdrop and updated burger label', () => {
+    render(<MobileMenuFixture />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open navigation menu' }));
+
+    const menu = document.getElementById('nav-mobile-links')!;
+    const backdrop = document.getElementById('nav-mobile-backdrop')!;
+    const shell = document.querySelector('.nav-shell') as HTMLElement;
+    const burger = screen.getByRole('button', { name: 'Close navigation menu' });
+    const status = document.getElementById('nav-menu-status')!;
+
+    expect(menu.classList.contains('active')).toBe(true);
+    expect(menu.dataset.state).toBe('open');
+    expect(backdrop.dataset.state).toBe('open');
+    expect(backdrop.getAttribute('aria-hidden')).toBe('false');
+    expect(shell.dataset.menuState).toBe('open');
+    expect(burger.getAttribute('aria-expanded')).toBe('true');
+    expect(status.textContent).toBe('Navigation menu opened');
+  });
+
+  it('closes the mobile menu when the burger is toggled again', () => {
+    render(<MobileMenuFixture />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open navigation menu' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close navigation menu' }));
+
+    const menu = document.getElementById('nav-mobile-links')!;
+    const backdrop = document.getElementById('nav-mobile-backdrop')!;
+    const shell = document.querySelector('.nav-shell') as HTMLElement;
+    const status = document.getElementById('nav-menu-status')!;
+
+    expect(menu.classList.contains('active')).toBe(false);
+    expect(menu.dataset.state).toBe('closed');
+    expect(backdrop.dataset.state).toBe('closed');
+    expect(shell.dataset.menuState).toBe('closed');
+    expect(screen.getByRole('button', { name: 'Open navigation menu' })).toBeTruthy();
+    expect(status.textContent).toBe('Navigation menu closed');
+  });
+
+  it('closes the mobile menu when the backdrop is clicked', () => {
+    render(<MobileMenuFixture />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open navigation menu' }));
+    fireEvent.click(document.getElementById('nav-mobile-backdrop')!);
+
+    const menu = document.getElementById('nav-mobile-links')!;
+    expect(menu.classList.contains('active')).toBe(false);
+    expect(menu.dataset.state).toBe('closed');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes Phase 3 of the nav/header improvement plan and fixes the **“pushed left, blank on right”** layout shift.

### Root cause
Scroll lock was fighting between overlays:
- `useMobileMenu` and `CommandCenter` both called `releaseScrollLock()` whenever closed — including on mount — which could unlock the body while another overlay was still open, or leave `position: fixed` stuck.
- `width: 100%` on a fixed `body` ignored the scrollbar gutter, shifting content left with empty space on the right.

### Fix
- Each overlay tracks whether **it** holds the lock (acquire/release only on owned transitions).
- Scroll lock uses `left: 0; right: 0; width: auto`, scrollbar `padding-right`, and `body.scroll-locked` with matching nav-shell padding.
- Layout regression tests cover menu/search open-close cycles.

### Phase 3 (prior commits)
- `useMobileMenu` hook + `registerNavTheme` extraction
- Navbar visual baselines in maintained `component-visual-baselines.spec.ts`
- Chromium-first visual CI scripts

## Test plan

- [x] `vitest run tests/vitest/scrollLock.test.ts tests/vitest/useMobileMenu.test.tsx`
- [x] `playwright test layout-scroll-lock.spec.ts menu-visibility-strict.spec.ts`
- [x] `npm run test:e2e:visual:chromium`
- [x] `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved mobile navigation behavior with better open/close handling, outside-click closing, and clearer accessibility labels.
  * Added theme toggle registration so the nav can follow and update color-scheme preference.
  * Added new visual test scripts for running and updating Chromium-based snapshots.

* **Bug Fixes**
  * Improved scroll locking so overlays restore page position cleanly and the header stays aligned.
  * Reduced layout shift issues when closing the mobile menu or search overlay.

* **Tests**
  * Expanded visual coverage for navigation states, scroll-lock cleanup, and more page routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->