### PR TITLE
Harden header overlays against scroll lock leaks

### DIFF
--- a/src/components/islands/NavBarIsland.tsx
+++ b/src/components/islands/NavBarIsland.tsx
@@ -11,6 +11,7 @@ import { normalizeNavPath } from '../../config/navLinks';
 import { useMobileMenu } from '../../features/nav/hooks/useMobileMenu';
 import { openCommandCenter } from '../../features/command-center/lib/commandEvents';
 import { registerModernNavBar } from '../../scripts/features/ModernNavBar';
+import { registerHeaderOverlayLifecycle } from '../../scripts/features/registerHeaderOverlayLifecycle';
 import { initMotionAccessibility } from '../../scripts/modules/MotionAccessibility';
 
 type LogoAvatar = {
@@ -65,6 +66,8 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
         themeToggle: themeToggleRef.current,
       });
 
+      const cleanupOverlayLifecycle = registerHeaderOverlayLifecycle();
+
       if (!(window as typeof window & { __motionAccessibilityInit?: boolean }).__motionAccessibilityInit) {
         initMotionAccessibility();
         (window as typeof window & { __motionAccessibilityInit?: boolean }).__motionAccessibilityInit = true;
@@ -83,6 +86,7 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
 
       return () => {
         cleanupNav?.();
+        cleanupOverlayLifecycle?.();
         document.removeEventListener('astro:page-load', syncActivePath);
         window.removeEventListener('scroll', handleScroll);
       };

--- a/src/features/command-center/CommandCenter.tsx
+++ b/src/features/command-center/CommandCenter.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { handoffToAiChat } from '../../lib/chat/ai-chat-bridge';
-import { acquireScrollLock, releaseScrollLock } from '../../utils/scrollLock';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock';
 import { createFocusTrap } from '../../utils/focusTrap';
 import { CommandAskHandoff, CommandAskPanel } from './components/CommandAskHandoff';
 import { CommandEmpty, CommandFooter } from './components/CommandEmpty';
@@ -29,7 +29,8 @@ type AskAiOptions = {
 };
 
 export default function CommandCenter() {
-  const { isOpen, close } = useCommandCenter();
+  const { isOpen, close: closeCommandCenter } = useCommandCenter();
+  const { releaseNow: releaseScrollLockNow } = useOverlayScrollLock(isOpen);
   const { recentQueries, pushQuery, clearHistory } = useCommandHistory();
   const { query, setQuery, category, setCategory, groups, isLoading, error } = useCommandQuery(isOpen);
 
@@ -39,7 +40,12 @@ export default function CommandCenter() {
   const panelRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const focusTrapRef = useRef<ReturnType<typeof createFocusTrap> | null>(null);
-  const scrollLockHeldRef = useRef(false);
+
+  const close = useCallback(() => {
+    releaseScrollLockNow();
+    focusTrapRef.current?.deactivate();
+    closeCommandCenter();
+  }, [closeCommandCenter, releaseScrollLockNow]);
 
   const flatItems = useMemo(() => flattenGroups(groups), [groups]);
   const hasResults = mode === 'find' && flatItems.length > 0;
@@ -129,18 +135,9 @@ export default function CommandCenter() {
 
   useEffect(() => {
     if (!isOpen) {
-      if (scrollLockHeldRef.current) {
-        releaseScrollLock();
-        scrollLockHeldRef.current = false;
-      }
       focusTrapRef.current?.deactivate();
       setActiveIndex(-1);
       return;
-    }
-
-    if (!scrollLockHeldRef.current) {
-      acquireScrollLock();
-      scrollLockHeldRef.current = true;
     }
 
     const toggleButton = document.getElementById('search-toggle');
@@ -155,10 +152,6 @@ export default function CommandCenter() {
 
     return () => {
       window.clearTimeout(timer);
-      if (scrollLockHeldRef.current) {
-        releaseScrollLock();
-        scrollLockHeldRef.current = false;
-      }
       focusTrapRef.current?.deactivate();
     };
   }, [isOpen]);

--- a/src/features/command-center/hooks/useCommandCenter.ts
+++ b/src/features/command-center/hooks/useCommandCenter.ts
@@ -134,6 +134,15 @@ export function useCommandCenter() {
   }, [open, toggle]);
 
   useEffect(() => {
+    const handlePageLoad = () => {
+      if (isOpen) close();
+    };
+
+    document.addEventListener('astro:page-load', handlePageLoad);
+    return () => document.removeEventListener('astro:page-load', handlePageLoad);
+  }, [isOpen, close]);
+
+  useEffect(() => {
     const cleanupEscape = registerEscapeHandler({
       id: 'command-center',
       priority: 2,

--- a/src/features/nav/hooks/useMobileMenu.ts
+++ b/src/features/nav/hooks/useMobileMenu.ts
@@ -1,15 +1,17 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 
+import { useOverlayScrollLock } from '../../../hooks/useOverlayScrollLock';
 import {
   closeSearch,
   registerEscapeHandler,
   registerMobileMenuClose,
 } from '../../../utils/headerController';
 import { createFocusTrap, type FocusTrap } from '../../../utils/focusTrap';
-import { acquireScrollLock, releaseScrollLock } from '../../../utils/scrollLock';
 
 export const MENU_LABEL_OPEN = 'Open navigation menu';
 export const MENU_LABEL_CLOSED = 'Close navigation menu';
+
+const DESKTOP_NAV_QUERY = '(min-width: 768px)';
 
 export type MobileMenuRefs = {
   menu: RefObject<HTMLElement | null>;
@@ -25,20 +27,16 @@ function getInitialMenuFocus(menu: HTMLElement): HTMLElement | null {
 export function useMobileMenu(refs: MobileMenuRefs) {
   const [isOpen, setIsOpen] = useState(false);
   const focusTrapRef = useRef<FocusTrap | null>(null);
-  const scrollLockHeldRef = useRef(false);
   const isOpenRef = useRef(isOpen);
+  const { releaseNow: releaseScrollLockNow } = useOverlayScrollLock(isOpen);
 
   isOpenRef.current = isOpen;
 
-  const releaseMenuScrollLock = () => {
-    if (!scrollLockHeldRef.current) return;
-    releaseScrollLock();
-    scrollLockHeldRef.current = false;
-  };
-
   const close = useCallback(() => {
+    releaseScrollLockNow();
+    focusTrapRef.current?.deactivate();
     setIsOpen(false);
-  }, []);
+  }, [releaseScrollLockNow]);
 
   const open = useCallback(() => {
     closeSearch();
@@ -66,21 +64,15 @@ export function useMobileMenu(refs: MobileMenuRefs) {
     const status = refs.status.current;
 
     if (isOpen) {
-      if (!scrollLockHeldRef.current) {
-        acquireScrollLock();
-        scrollLockHeldRef.current = true;
-      }
       trap.activate();
       if (status) status.textContent = 'Navigation menu opened';
     } else {
       trap.deactivate();
-      releaseMenuScrollLock();
       if (status) status.textContent = 'Navigation menu closed';
     }
 
     return () => {
       trap.deactivate();
-      releaseMenuScrollLock();
     };
   }, [isOpen, refs.menu, refs.burger, refs.status]);
 
@@ -121,6 +113,29 @@ export function useMobileMenu(refs: MobileMenuRefs) {
     document.addEventListener('click', outsideClickHandler);
     return () => document.removeEventListener('click', outsideClickHandler);
   }, [isOpen, close, refs.menu, refs.burger, refs.backdrop]);
+
+  useEffect(() => {
+    const handlePageLoad = () => {
+      if (isOpenRef.current) close();
+    };
+
+    document.addEventListener('astro:page-load', handlePageLoad);
+    return () => document.removeEventListener('astro:page-load', handlePageLoad);
+  }, [close]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia?.(DESKTOP_NAV_QUERY);
+    if (!mediaQuery) return;
+
+    const handleViewportChange = (event: MediaQueryListEvent) => {
+      if (event.matches && isOpenRef.current) close();
+    };
+
+    mediaQuery.addEventListener('change', handleViewportChange);
+    if (mediaQuery.matches && isOpenRef.current) close();
+
+    return () => mediaQuery.removeEventListener('change', handleViewportChange);
+  }, [close]);
 
   const onBurgerClick = useCallback(
     (event: React.MouseEvent) => {

--- a/src/hooks/useOverlayScrollLock.ts
+++ b/src/hooks/useOverlayScrollLock.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { acquireScrollLock, releaseScrollLock } from '../utils/scrollLock';
+
+/**
+ * Reference-counted scroll lock for a single overlay owner.
+ * Call `releaseNow()` synchronously when closing to avoid layout drift during route changes.
+ */
+export function useOverlayScrollLock(enabled: boolean) {
+  const heldRef = useRef(false);
+
+  const releaseNow = useCallback(() => {
+    if (!heldRef.current) return;
+    releaseScrollLock();
+    heldRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    if (enabled) {
+      if (!heldRef.current) {
+        acquireScrollLock();
+        heldRef.current = true;
+      }
+    } else {
+      releaseNow();
+    }
+
+    return releaseNow;
+  }, [enabled, releaseNow]);
+
+  return { releaseNow };
+}

--- a/src/scripts/features/index.ts
+++ b/src/scripts/features/index.ts
@@ -1,3 +1,4 @@
 // Feature Scripts - UI features and interactions
 export { registerModernNavBar } from './ModernNavBar';
 export { registerNavTheme } from './registerNavTheme';
+export { registerHeaderOverlayLifecycle } from './registerHeaderOverlayLifecycle';

--- a/src/scripts/features/registerHeaderOverlayLifecycle.ts
+++ b/src/scripts/features/registerHeaderOverlayLifecycle.ts
@@ -1,0 +1,29 @@
+import { closeAllHeaderOverlays } from '../../utils/headerController';
+import { forceReleaseScrollLock } from '../../utils/scrollLock';
+
+type CleanupFn = () => void;
+
+/**
+ * Close header overlays on Astro client navigations so persisted nav/search
+ * state does not leak across routes with scroll lock attached.
+ */
+export function registerHeaderOverlayLifecycle(): CleanupFn {
+  if (typeof document === 'undefined') return () => undefined;
+
+  const handlePageLoad = () => {
+    closeAllHeaderOverlays();
+    requestAnimationFrame(() => {
+      const menuOpen = document.getElementById('nav-mobile-links')?.classList.contains('active');
+      const searchOpen = document.getElementById('search-overlay')?.getAttribute('data-state') === 'open';
+      if (!menuOpen && !searchOpen) {
+        forceReleaseScrollLock();
+      }
+    });
+  };
+
+  document.addEventListener('astro:page-load', handlePageLoad);
+
+  return () => {
+    document.removeEventListener('astro:page-load', handlePageLoad);
+  };
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -129,6 +129,10 @@
     padding-right: var(--scrollbar-width, 0px);
   }
 
+  body.scroll-locked [data-ai-chat-widget] {
+    padding-right: var(--scrollbar-width, 0px);
+  }
+
   /* Burger → close icon animation */
   .burger-icon {
     display: flex;

--- a/src/utils/headerController.ts
+++ b/src/utils/headerController.ts
@@ -86,6 +86,13 @@ export function closeAiChat(): void {
   closeAiChatFn?.();
 }
 
+/** Close every registered header overlay (mobile menu, search, AI chat). */
+export function closeAllHeaderOverlays(): void {
+  closeMobileMenu();
+  closeSearch();
+  closeAiChat();
+}
+
 export function resetHeaderControllerForTests(): void {
   escapeHandlers.length = 0;
   closeMobileMenuFn = null;

--- a/src/utils/scrollLock.ts
+++ b/src/utils/scrollLock.ts
@@ -70,6 +70,13 @@ export function isScrollLocked(): boolean {
   return lockCount > 0;
 }
 
+/** Emergency unlock — use only when all overlays have been closed (e.g. Astro view transitions). */
+export function forceReleaseScrollLock(): void {
+  if (typeof document === 'undefined') return;
+  lockCount = 0;
+  clearScrollLockStyles();
+}
+
 export function resetScrollLockForTests(): void {
   lockCount = 0;
   savedScrollY = 0;

--- a/tests/playwright/layout-scroll-lock.spec.ts
+++ b/tests/playwright/layout-scroll-lock.spec.ts
@@ -80,4 +80,29 @@ test.describe('Page layout after overlays @essential', () => {
     expect(after.bodyPosition).toBe('static');
     expect(after.mainLeft).toBe(0);
   });
+
+  test('mobile menu closes on Astro client navigation', async ({ page }) => {
+    await page.locator('#nav-toggle').click();
+    await expect(page.locator('#nav-mobile-links')).toHaveClass(/active/);
+
+    await page.evaluate(() => {
+      document.dispatchEvent(new Event('astro:page-load'));
+    });
+
+    await expect(page.locator('#nav-mobile-links')).not.toHaveClass(/active/);
+    const after = await readLayout(page);
+    expect(after.bodyPosition).toBe('static');
+  });
+
+  test('mobile menu closes when viewport expands to desktop', async ({ page }) => {
+    await page.locator('#nav-toggle').click();
+    await expect(page.locator('#nav-mobile-links')).toHaveClass(/active/);
+
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.waitForTimeout(100);
+
+    await expect(page.locator('#nav-mobile-links')).not.toHaveClass(/active/);
+    const after = await readLayout(page);
+    expect(after.bodyPosition).toBe('static');
+  });
 });

--- a/tests/vitest/headerController.test.ts
+++ b/tests/vitest/headerController.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   closeMobileMenu,
   closeSearch,
+  closeAllHeaderOverlays,
   registerEscapeHandler,
   registerMobileMenuClose,
   registerSearchClose,
@@ -59,6 +60,19 @@ describe('headerController', () => {
 
     closeMobileMenu();
     closeSearch();
+
+    expect(menuClose).toHaveBeenCalledOnce();
+    expect(searchClose).toHaveBeenCalledOnce();
+  });
+
+  it('closes every registered header overlay', () => {
+    const menuClose = vi.fn();
+    const searchClose = vi.fn();
+
+    registerMobileMenuClose(menuClose);
+    registerSearchClose(searchClose);
+
+    closeAllHeaderOverlays();
 
     expect(menuClose).toHaveBeenCalledOnce();
     expect(searchClose).toHaveBeenCalledOnce();

--- a/tests/vitest/scrollLock.test.ts
+++ b/tests/vitest/scrollLock.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   acquireScrollLock,
+  forceReleaseScrollLock,
   releaseScrollLock,
   isScrollLocked,
   resetScrollLockForTests,
@@ -48,5 +49,13 @@ describe('scrollLock', () => {
     expect(document.body.style.left).toBe('0px');
     expect(document.body.style.right).toBe('0px');
     expect(document.body.style.width).toBe('auto');
+  });
+
+  it('forceReleaseScrollLock clears a stuck lock', () => {
+    acquireScrollLock();
+    acquireScrollLock();
+    forceReleaseScrollLock();
+    expect(isScrollLocked()).toBe(false);
+    expect(document.body.style.position).toBe('');
   });
 });

--- a/tests/vitest/useOverlayScrollLock.test.tsx
+++ b/tests/vitest/useOverlayScrollLock.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { useState } from 'react';
+
+import { useOverlayScrollLock } from '../../src/hooks/useOverlayScrollLock';
+import {
+  acquireScrollLock,
+  isScrollLocked,
+  resetScrollLockForTests,
+} from '../../src/utils/scrollLock';
+
+function ScrollLockHarness() {
+  const [enabled, setEnabled] = useState(false);
+  const { releaseNow } = useOverlayScrollLock(enabled);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setEnabled(true)}>
+        Enable
+      </button>
+      <button type="button" onClick={() => setEnabled(false)}>
+        Disable
+      </button>
+      <button type="button" onClick={() => releaseNow()}>
+        Release now
+      </button>
+    </div>
+  );
+}
+
+describe('useOverlayScrollLock', () => {
+  beforeEach(() => {
+    resetScrollLockForTests();
+    document.body.style.cssText = '';
+    document.body.className = '';
+  });
+
+  afterEach(() => {
+    resetScrollLockForTests();
+  });
+
+  it('acquires and releases scroll lock with enabled state', async () => {
+    const { getByRole } = render(<ScrollLockHarness />);
+
+    await act(async () => {
+      getByRole('button', { name: 'Enable' }).click();
+    });
+    expect(isScrollLocked()).toBe(true);
+
+    await act(async () => {
+      getByRole('button', { name: 'Disable' }).click();
+    });
+    expect(isScrollLocked()).toBe(false);
+  });
+
+  it('releaseNow clears lock synchronously while still enabled', async () => {
+    const { getByRole } = render(<ScrollLockHarness />);
+
+    await act(async () => {
+      getByRole('button', { name: 'Enable' }).click();
+    });
+    expect(isScrollLocked()).toBe(true);
+
+    await act(async () => {
+      getByRole('button', { name: 'Release now' }).click();
+    });
+    expect(isScrollLocked()).toBe(false);
+    expect(document.body.style.position).toBe('');
+  });
+
+  it('does not release locks owned by another overlay', () => {
+    acquireScrollLock();
+    const { getByRole } = render(<ScrollLockHarness />);
+
+    getByRole('button', { name: 'Enable' }).click();
+    expect(isScrollLocked()).toBe(true);
+
+    getByRole('button', { name: 'Release now' }).click();
+    expect(isScrollLocked()).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up hardening after the scroll-lock layout shift fix.

- **`useOverlayScrollLock`** — shared hook with `releaseNow()` for synchronous unlock on close
- **Mobile menu** — closes on Astro client navigations and when viewport crosses the `md` breakpoint
- **Command Center** — closes on Astro navigations; scroll lock uses the shared hook
- **`registerHeaderOverlayLifecycle`** — closes all header overlays on `astro:page-load` with `forceReleaseScrollLock` fallback
- **`closeAllHeaderOverlays()`** — centralized close API in `headerController`
- **CSS** — scrollbar padding for AI chat widget while scroll-locked

## Test plan

- [x] Vitest: `useOverlayScrollLock`, `scrollLock`, `headerController`, `useMobileMenu`
- [x] Playwright: `layout-scroll-lock.spec.ts` (5 tests incl. Astro nav + resize)
- [x] `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved overlay behavior for the mobile menu, command center, and header overlays during page navigation.
  * Added a more reliable scroll-lock experience for open overlays and the AI chat widget.

* **Bug Fixes**
  * Overlays now close more consistently when navigating, switching to desktop, or reloading the page.
  * Fixed cases where the page could remain scroll-locked after closing an overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->