### PR TITLE
Mobile hide-on-scroll header and nav.json sync guard

### DIFF
--- a/functions/edge-computing.js
+++ b/functions/edge-computing.js
@@ -1173,7 +1173,8 @@ Provide concise, professional responses (2-3 sentences) for simple questions. Be
       }
     }
 
-    // Back-compat asset rewrite: maintain existing path if older HTML referenced it
+    // Back-compat asset rewrite: legacy HTML may still request the standalone bundle.
+    // Production search is Command Center — see src/features/command-center/.
     if (url.pathname === '/assets/js/search-overlay-standalone.min.js' && url.search === '?v=2') {
       return env.ASSETS.fetch(request);
     }

--- a/src/components/islands/NavBarIsland.tsx
+++ b/src/components/islands/NavBarIsland.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { NavLink } from '../../config/navLinks';
 import { normalizeNavPath } from '../../config/navLinks';
 import { useMobileMenu } from '../../features/nav/hooks/useMobileMenu';
+import { useNavScrollBehavior } from '../../features/nav/hooks/useNavScrollBehavior';
 import { openCommandCenter } from '../../features/command-center/lib/commandEvents';
 import { registerModernNavBar } from '../../scripts/features/ModernNavBar';
 import { registerHeaderOverlayLifecycle } from '../../scripts/features/registerHeaderOverlayLifecycle';
@@ -49,6 +50,11 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
     status: menuStatusRef,
   });
 
+  const { isAutoHidden } = useNavScrollBehavior(
+    { shell: shellRef, nav: navRef },
+    { blockAutoHide: isOpen },
+  );
+
   useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') {
       return;
@@ -73,22 +79,10 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
         (window as typeof window & { __motionAccessibilityInit?: boolean }).__motionAccessibilityInit = true;
       }
 
-      const navEl = navRef.current;
-      const shellEl = shellRef.current;
-      const handleScroll = () => {
-        if (!navEl) return;
-        const scrolled = window.scrollY > 80;
-        navEl.classList.toggle('has-background', scrolled);
-        shellEl?.classList.toggle('nav-shell--scrolled', scrolled);
-      };
-      handleScroll();
-      window.addEventListener('scroll', handleScroll, { passive: true });
-
       return () => {
         cleanupNav?.();
         cleanupOverlayLifecycle?.();
         document.removeEventListener('astro:page-load', syncActivePath);
-        window.removeEventListener('scroll', handleScroll);
       };
     } catch (err) {
       console.error('[NavBarIsland] hydration error', err);
@@ -129,7 +123,7 @@ export default function NavBarIsland({ links, logo, currentPath }: NavBarIslandP
   return (
     <div
       ref={shellRef}
-      className="@container nav-shell relative overflow-visible sticky top-0 z-nav border-b border-border/40 bg-[color:var(--glass-surface-bg)] backdrop-blur supports-[backdrop-filter]:bg-[color:var(--glass-surface-bg-xl)]"
+      className={`@container nav-shell relative overflow-visible sticky top-0 z-nav border-b border-border/40 bg-[color:var(--glass-surface-bg)] backdrop-blur supports-[backdrop-filter]:bg-[color:var(--glass-surface-bg-xl)] motion-safe:transition-transform motion-safe:duration-normal md:motion-safe:transition-none${isAutoHidden ? ' nav-shell--auto-hidden' : ''}`}
       data-menu-state={isOpen ? 'open' : 'closed'}
     >
       <div

--- a/src/content/navigation/README.md
+++ b/src/content/navigation/README.md
@@ -5,3 +5,5 @@ The live site navigation is driven by **`src/config/navLinks.ts`**, which powers
 The JSON files in this folder are a **content-collection mirror** for documentation and future CMS-style workflows. They are not loaded by the production nav bar today.
 
 When updating navigation labels or hrefs, change `navLinks.ts` first, then sync these JSON files if you want them to stay aligned.
+
+CI enforces link parity via `tests/vitest/navLinksSync.test.ts`.

--- a/src/content/navigation/nav.json
+++ b/src/content/navigation/nav.json
@@ -46,7 +46,7 @@
       "icon": "github"
     },
     {
-      "href": "https://linkedin.com/in/blakeoxford",
+      "href": "https://linkedin.com/in/blake-oxford",
       "label": "LinkedIn",
       "icon": "linkedin"
     },

--- a/src/features/nav/hooks/useNavScrollBehavior.ts
+++ b/src/features/nav/hooks/useNavScrollBehavior.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState, type RefObject } from 'react';
+
+const SCROLL_COMPACT_THRESHOLD = 80;
+const SCROLL_DIRECTION_DELTA = 12;
+
+type NavScrollRefs = {
+  shell: RefObject<HTMLElement | null>;
+  nav: RefObject<HTMLElement | null>;
+};
+
+type NavScrollOptions = {
+  /** When true, auto-hide is suppressed (mobile menu open, etc.). */
+  blockAutoHide?: boolean;
+};
+
+function isCommandCenterOpen(): boolean {
+  return document.getElementById('search-overlay')?.getAttribute('data-state') === 'open';
+}
+
+/**
+ * Compact header on scroll and auto-hide when scrolling down (mobile only).
+ * Re-shows when the user scrolls up or returns near the top.
+ */
+export function useNavScrollBehavior(refs: NavScrollRefs, options: NavScrollOptions = {}) {
+  const lastScrollY = useRef(0);
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [isAutoHidden, setIsAutoHidden] = useState(false);
+
+  useEffect(() => {
+    const shell = refs.shell.current;
+    const nav = refs.nav.current;
+    if (!shell || !nav) return;
+
+    const handleScroll = () => {
+      const scrollY = window.scrollY;
+      const compact = scrollY > SCROLL_COMPACT_THRESHOLD;
+
+      nav.classList.toggle('has-background', compact);
+      shell.classList.toggle('nav-shell--scrolled', compact);
+      setIsScrolled(compact);
+
+      const shouldBlockHide =
+        options.blockAutoHide || isCommandCenterOpen() || scrollY <= SCROLL_COMPACT_THRESHOLD;
+
+      if (shouldBlockHide) {
+        setIsAutoHidden(false);
+      } else if (scrollY > lastScrollY.current + SCROLL_DIRECTION_DELTA) {
+        setIsAutoHidden(true);
+      } else if (scrollY < lastScrollY.current - SCROLL_DIRECTION_DELTA) {
+        setIsAutoHidden(false);
+      }
+
+      lastScrollY.current = scrollY;
+    };
+
+    const resetOnNavigation = () => {
+      lastScrollY.current = window.scrollY;
+      setIsAutoHidden(false);
+      handleScroll();
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    document.addEventListener('astro:page-load', resetOnNavigation);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      document.removeEventListener('astro:page-load', resetOnNavigation);
+    };
+  }, [options.blockAutoHide, refs.shell, refs.nav]);
+
+  return { isScrolled, isAutoHidden };
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -106,6 +106,21 @@
     height: 4rem;
   }
 
+  /* Mobile: tuck header away while scrolling down; restored on scroll up */
+  @media (max-width: 767px) {
+    .nav-shell--auto-hidden:not([data-menu-state='open']) {
+      pointer-events: none;
+      transform: translateY(calc(-1 * var(--nav-height, 4.5rem)));
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nav-shell--auto-hidden {
+      transform: none !important;
+      pointer-events: auto !important;
+    }
+  }
+
   /* Scroll-aware sticky header shell */
   .nav-shell:has(#navbar.has-background) {
     border-color: color-mix(in oklch, var(--border) 85%, transparent);

--- a/tests/playwright/nav-scroll-hide.spec.ts
+++ b/tests/playwright/nav-scroll-hide.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Mobile nav auto-hide @essential', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+    await page.waitForFunction(() => (window as Window & { __navHydrated?: boolean }).__navHydrated === true, {
+      timeout: 10000,
+    });
+  });
+
+  test('hides the header while scrolling down and restores on scroll up', async ({ page }) => {
+    await page.mouse.move(195, 400);
+
+    for (let i = 0; i < 6; i += 1) {
+      await page.mouse.wheel(0, 120);
+      await page.waitForTimeout(40);
+    }
+
+    await expect(page.locator('.nav-shell')).toHaveClass(/nav-shell--auto-hidden/);
+
+    for (let i = 0; i < 4; i += 1) {
+      await page.mouse.wheel(0, -160);
+      await page.waitForTimeout(40);
+    }
+
+    await page.waitForFunction(
+      () => !document.querySelector('.nav-shell')?.classList.contains('nav-shell--auto-hidden'),
+      { timeout: 5000 },
+    );
+  });
+
+  test('does not auto-hide while the mobile menu is open', async ({ page }) => {
+    await page.locator('#nav-toggle').click();
+    await expect(page.locator('#nav-mobile-links')).toHaveClass(/active/);
+
+    await page.evaluate(() => window.scrollTo(0, 360));
+    await page.waitForTimeout(100);
+
+    await expect(page.locator('.nav-shell')).not.toHaveClass(/nav-shell--auto-hidden/);
+  });
+});

--- a/tests/vitest/navLinksSync.test.ts
+++ b/tests/vitest/navLinksSync.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import navLinks, { navConfig } from '../../src/config/navLinks';
+
+type NavJson = {
+  links: Array<{ href: string; label: string }>;
+  socialLinks?: Array<{ href: string; label: string }>;
+};
+
+function loadNavJson(): NavJson {
+  const filePath = path.join(process.cwd(), 'src/content/navigation/nav.json');
+  return JSON.parse(readFileSync(filePath, 'utf8')) as NavJson;
+}
+
+function normalizeLinks(links: Array<{ href: string; label: string }>) {
+  return links.map((link) => ({ href: link.href, label: link.label }));
+}
+
+describe('navLinks sync with nav.json', () => {
+  const navJson = loadNavJson();
+
+  it('keeps primary links aligned with the content collection mirror', () => {
+    expect(normalizeLinks(navJson.links)).toEqual(normalizeLinks(navLinks));
+  });
+
+  it('keeps social link hrefs aligned with navConfig', () => {
+    const jsonSocial = (navJson.socialLinks ?? []).map((link) => link.href).sort();
+    const tsSocial = (navConfig.socialLinks ?? []).map((link) => link.href).sort();
+    expect(jsonSocial).toEqual(tsSocial);
+  });
+});

--- a/tests/vitest/useNavScrollBehavior.test.tsx
+++ b/tests/vitest/useNavScrollBehavior.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { useRef } from 'react';
+
+import { useNavScrollBehavior } from '../../src/features/nav/hooks/useNavScrollBehavior';
+
+function ScrollHarness({ blockAutoHide = false }: { blockAutoHide?: boolean }) {
+  const shellRef = useRef<HTMLDivElement>(null);
+  const navRef = useRef<HTMLElement>(null);
+  const { isScrolled, isAutoHidden } = useNavScrollBehavior(
+    { shell: shellRef, nav: navRef },
+    { blockAutoHide },
+  );
+
+  return (
+    <div>
+      <div ref={shellRef} className={`nav-shell${isAutoHidden ? ' nav-shell--auto-hidden' : ''}`}>
+        <nav ref={navRef} id="navbar" />
+      </div>
+      <output data-scrolled={isScrolled ? 'true' : 'false'} />
+      <output data-hidden={isAutoHidden ? 'true' : 'false'} />
+    </div>
+  );
+}
+
+describe('useNavScrollBehavior', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true });
+    document.body.style.minHeight = '2000px';
+  });
+
+  afterEach(() => {
+    document.body.style.minHeight = '';
+  });
+
+  it('marks the header compact after scrolling past the threshold', async () => {
+    const { container } = render(<ScrollHarness />);
+    const nav = container.querySelector('#navbar') as HTMLElement;
+
+    await act(async () => {
+      window.scrollY = 120;
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(nav.classList.contains('has-background')).toBe(true);
+    expect(container.querySelector('output[data-scrolled="true"]')).toBeTruthy();
+  });
+
+  it('auto-hides on downward scroll and restores on upward scroll', async () => {
+    const { container } = render(<ScrollHarness />);
+
+    await act(async () => {
+      window.scrollY = 200;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    await act(async () => {
+      window.scrollY = 260;
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(container.querySelector('.nav-shell--auto-hidden')).toBeTruthy();
+
+    await act(async () => {
+      window.scrollY = 220;
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(container.querySelector('.nav-shell--auto-hidden')).toBeFalsy();
+  });
+
+  it('does not auto-hide while blockAutoHide is true', async () => {
+    const { container } = render(<ScrollHarness blockAutoHide />);
+
+    await act(async () => {
+      window.scrollY = 260;
+      window.dispatchEvent(new Event('scroll'));
+    });
+    await act(async () => {
+      window.scrollY = 320;
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(container.querySelector('.nav-shell--auto-hidden')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Mobile hide-on-scroll** — `useNavScrollBehavior` tucks the header away while scrolling down on viewports `<768px`; restores on scroll up or near the top
- **Safe guards** — auto-hide blocked while mobile menu or Command Center is open; disabled under `prefers-reduced-motion`
- **nav.json sync** — Vitest guard ensures `navLinks.ts` and `nav.json` stay aligned; fixed LinkedIn href drift
- **Docs** — navigation README notes the CI parity test

## Test plan

- [x] Vitest: `useNavScrollBehavior`, `navLinksSync`, `useMobileMenu`
- [x] Playwright: `nav-scroll-hide.spec.ts` (2 tests, `@essential`)
- [x] `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

