### PR TITLE
Mobile auto-hidden nav baseline and nav testing docs

### DIFF
--- a/src/data/componentDocs.ts
+++ b/src/data/componentDocs.ts
@@ -73,10 +73,12 @@ export const componentDocs: ComponentDoc[] = [
       },
     ],
     accessibility: [
-      'Semantic nav element (handled by island)',
-      'Keyboard navigation support',
-      'Mobile menu with proper ARIA attributes',
-      'Focus management for menu toggle',
+      'Semantic nav element',
+      'Mobile menu with ARIA attributes',
+      'Keyboard navigation (Tab, Enter, Escape)',
+      'Focus trap in mobile drawer with return focus to burger',
+      'Auto-hide on scroll down (all viewports); blocked when menu or Command Center is open',
+      'Screen reader status announcements via aria-live',
     ],
     tags: ['navigation', 'layout', 'mobile-menu', 'responsive'],
     visualTier: 'quiet',
@@ -434,7 +436,7 @@ export const componentDocs: ComponentDoc[] = [
   {
     name: 'NavBarIsland',
     category: 'Islands',
-    description: 'React island for site navigation. Interactive navigation bar with mobile menu, logo, and responsive design. Integrates ModernNavBar and MotionAccessibility for enhanced UX.',
+    description: 'React island for site navigation. Interactive navigation bar with mobile menu, logo, and responsive design. Scroll-aware compact header and auto-hide on all viewports.',
     filePath: 'src/components/islands/NavBarIsland.tsx',
     props: [
       { name: 'links', type: 'NavLink[]', required: true, description: 'Navigation links configuration' },

--- a/src/data/componentVisualBaselines.ts
+++ b/src/data/componentVisualBaselines.ts
@@ -13,6 +13,7 @@ export type ComponentVisualBaselineKey =
   | 'navbarMobileOpen'
   | 'navbarScrolled'
   | 'navbarAutoHidden'
+  | 'navbarMobileAutoHidden'
   | 'footer'
   | 'searchOverlay'
   | 'commandCenterResults'
@@ -85,6 +86,17 @@ export const componentVisualBaselines: Record<ComponentVisualBaselineKey, Compon
     tags: ['@visual-essential', '@visual-components'],
     navSetup: 'autoHidden',
     screenshotClip: { x: 0, y: 0, width: 1280, height: 88 },
+  },
+  navbarMobileAutoHidden: {
+    key: 'navbarMobileAutoHidden',
+    route: '/',
+    selector: 'header .nav-shell',
+    description: 'Mobile navigation tucked away after scrolling down',
+    snapshotFile: 'navbarMobileAutoHidden.png',
+    tags: ['@visual-essential', '@visual-components'],
+    viewport: { width: 390, height: 844 },
+    navSetup: 'autoHidden',
+    screenshotClip: { x: 0, y: 0, width: 390, height: 88 },
   },
   footer: {
     key: 'footer',

--- a/src/pages/design/tokens.astro
+++ b/src/pages/design/tokens.astro
@@ -67,6 +67,13 @@ const stackingLayers = [
  { token: '--nav-height', value: '4.5rem (72px)', usage: 'Header height; compacts to 4rem when scrolled' },
 ];
 
+const navScrollBehavior = [
+ { class: '.nav-shell--scrolled', usage: 'Compact header after ~80px scroll; navbar height drops to 4rem' },
+ { class: '.nav-shell--auto-hidden', usage: 'Header tucked away on scroll down; restored on scroll up or near top' },
+ { class: '[data-menu-state="open"]', usage: 'Suppresses auto-hide while the mobile drawer is open' },
+ { class: 'prefers-reduced-motion', usage: 'Disables auto-hide transform; header stays visible' },
+];
+
 const radiusScale = [
  { token: 'rounded-lg', usage: 'Buttons, inputs, compact controls' },
  { token: 'rounded-xl', usage: 'Small cards and grouped controls' },
@@ -186,6 +193,34 @@ const stylesheetRoles = [
  </tbody>
  </table>
  </div>
+ </section>
+
+ <section class="mt-16" aria-labelledby="nav-scroll-behavior">
+ <h2 id="nav-scroll-behavior" class="text-2xl font-bold text-foreground">Navigation Scroll Behavior</h2>
+ <p class="mt-3 max-w-3xl text-muted-foreground">
+ Header scroll states are driven by <code class="rounded bg-surface-subtle px-1.5 py-0.5 text-sm dark:bg-surface-dark-subtle">useNavScrollBehavior</code> in the NavBar island. Auto-hide applies on all viewports; Command Center and an open mobile drawer block it.
+ </p>
+ <div class="mt-6 overflow-x-auto rounded-2xl border border-border/40 bg-surface shadow-sm dark:border-border-dark/40 dark:bg-surface-dark">
+ <table class="min-w-full text-left text-sm">
+ <thead class="border-b border-border/40 bg-surface-subtle/60 text-subtle-foreground dark:border-border-dark/40">
+ <tr>
+ <th class="px-4 py-3 font-semibold">Class / media</th>
+ <th class="px-4 py-3 font-semibold">Usage</th>
+ </tr>
+ </thead>
+ <tbody>
+ {navScrollBehavior.map((row) => (
+ <tr class="border-b border-border/20 last:border-0 dark:border-border-dark/20">
+ <td class="px-4 py-3"><code class="text-accent">{row.class}</code></td>
+ <td class="px-4 py-3 text-muted-foreground">{row.usage}</td>
+ </tr>
+ ))}
+ </tbody>
+ </table>
+ </div>
+ <p class="mt-4 text-sm text-muted-foreground">
+ Visual baselines: <code>navbarScrolled</code>, <code>navbarAutoHidden</code>, <code>navbarMobileAutoHidden</code> in <code>componentVisualBaselines.ts</code>.
+ </p>
  </section>
 
  <section class="mt-16" aria-labelledby="color-tokens">

--- a/tests/README.md
+++ b/tests/README.md
@@ -258,5 +258,31 @@ Heuristics:
 - Avoid raising global retries above 1; prefer deterministic utilities (`tests/utils/waits.ts`) to reduce variance.
 - History automatically prunes zero-test placeholder runs to keep signal clean.
 
+## Navigation Test Matrix (NavBar / Command Center)
 
+Fast essential nav checks (Chromium):
+
+```bash
+npx playwright test tests/playwright/menu-visibility-strict.spec.ts \
+  tests/playwright/mobile-navigation-essential.spec.ts \
+  tests/playwright/layout-scroll-lock.spec.ts \
+  tests/playwright/nav-scroll-hide.spec.ts --project=chromium
+```
+
+Extended device matrix (opt-in):
+
+```bash
+pnpm run test:e2e:device-matrix
+```
+
+Visual nav baselines (`navbar`, mobile open/closed, scrolled, auto-hidden):
+
+```bash
+npm run test:e2e:visual:chromium
+npm run test:e2e:visual:update   # regenerate snapshots after intentional UI changes
+```
+
+Unit hooks: `tests/vitest/useMobileMenu.test.tsx`, `useNavScrollBehavior.test.tsx`, `useOverlayScrollLock.test.tsx`, `navLinksSync.test.ts`.
+
+Config source of truth: `src/content/navigation/nav.json` (imported by `src/config/navLinks.ts`).
 

--- a/tests/playwright/component-visual-baselines.spec.ts
+++ b/tests/playwright/component-visual-baselines.spec.ts
@@ -15,6 +15,7 @@ const NAV_BASELINE_KEYS = [
   'navbarMobileOpen',
   'navbarScrolled',
   'navbarAutoHidden',
+  'navbarMobileAutoHidden',
 ] as const satisfies readonly ComponentVisualBaselineKey[];
 
 async function capturePreview(page: Page, route: string, name: string) {

--- a/tests/playwright/visual/_navVisualSetup.ts
+++ b/tests/playwright/visual/_navVisualSetup.ts
@@ -17,7 +17,9 @@ export async function setupNavVisual(page: Page, cfg: ComponentVisualBaseline) {
   }
 
   if (cfg.navSetup === 'autoHidden') {
-    await page.mouse.move(640, 400);
+    const width = cfg.viewport?.width ?? 1280;
+    const height = cfg.viewport?.height ?? 800;
+    await page.mouse.move(width / 2, height / 2);
     for (let i = 0; i < 8; i += 1) {
       await page.mouse.wheel(0, 150);
       await page.waitForTimeout(40);

--- a/tests/vitest/ContactForm.test.ts
+++ b/tests/vitest/ContactForm.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 
-// TODO: Convert to Playwright e2e tests - Astro components with nested components
-// cannot be reliably tested as unit tests due to complex rendering pipeline
+// Contact form HTML contract tests; full interaction covered by Playwright accessibility specs.
 describe('Contact form validation', () => {
   let form: HTMLFormElement;
 

--- a/tests/vitest/ProjectCard.test.ts
+++ b/tests/vitest/ProjectCard.test.ts
@@ -7,7 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const filePath = path.resolve(__dirname, '../../src/components/features/projects/ProjectCard.astro');
 let content: string;
 
-// TODO: Convert to Playwright e2e tests for real component rendering
+// Static markup contract tests for ProjectCard.astro (rendering covered by Playwright visual baselines).
 describe('ProjectCard.astro file', () => {
   beforeAll(() => {
     content = fs.readFileSync(filePath, 'utf-8');

--- a/tests/vitest/useMobileMenu.test.tsx
+++ b/tests/vitest/useMobileMenu.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { useRef } from 'react';
 
 import { useMobileMenu } from '../../src/features/nav/hooks/useMobileMenu';
-import { resetHeaderControllerForTests } from '../../src/utils/headerController';
+import { closeSearch, resetHeaderControllerForTests } from '../../src/utils/headerController';
 import { resetScrollLockForTests } from '../../src/utils/scrollLock';
 
 vi.mock('../../src/utils/headerController', async (importOriginal) => {
@@ -122,5 +122,13 @@ describe('useMobileMenu', () => {
     const menu = document.getElementById('nav-mobile-links')!;
     expect(menu.classList.contains('active')).toBe(false);
     expect(menu.dataset.state).toBe('closed');
+  });
+
+  it('closes command center search when opening the mobile menu', () => {
+    render(<MobileMenuFixture />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open navigation menu' }));
+
+    expect(vi.mocked(closeSearch)).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `navbarMobileAutoHidden` visual baseline (390×844 viewport clip).
- Makes auto-hide scroll setup viewport-aware in `_navVisualSetup.ts`.
- Documents nav scroll behavior on `/design/tokens/` and in `componentDocs.ts`.
- Adds Navigation Test Matrix section to `tests/README.md`.
- Adds Vitest asserting `closeSearch()` runs when the mobile menu opens.

## Test plan

- [x] `npx vitest run` useMobileMenu + componentDocs
- [x] `npm run test:e2e:visual:chromium` (12 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, visual regression coverage, and test helpers with no production nav logic in the diff.
> 
> **Overview**
> Adds a **mobile auto-hidden** Playwright visual baseline (`navbarMobileAutoHidden` at 390×844) and wires it into the component visual spec. Auto-hide setup now centers the mouse using each baseline’s viewport instead of a fixed desktop position.
> 
> **Design docs** on `/design/tokens/` gain a Navigation Scroll Behavior section (scroll classes, menu-state guard, reduced motion). **Component catalog** copy for NavBar / NavBarIsland is updated to match scroll-aware auto-hide, focus trap, and Command Center interaction.
> 
> **tests/README.md** documents a Navigation Test Matrix (essential Playwright commands, device matrix, visual baselines, related Vitest hooks). A Vitest case asserts `closeSearch()` when the mobile menu opens; ContactForm / ProjectCard test headers are clarified as markup contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8017eb45305c06e6a56ffcd6c194145eaee0eaa4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved navigation documentation for scroll-aware auto-hide behavior, including mobile menu accessibility details and screen-reader announcements.
  * Added a new visual baseline for the mobile auto-hidden navigation state.

* **Bug Fixes**
  * Improved navigation auto-hide visual testing to work reliably across viewport sizes.
  * Opening the mobile menu now closes the search panel as expected.

* **Documentation**
  * Expanded the navigation test guide with clearer commands and coverage notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->