### PR TITLE
Fix BlogPost type, wire nav quickLinks, bump github-script

### DIFF
--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Validate PR source/target
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -415,7 +415,7 @@ jobs:
           path: ./artifacts/macos
         continue-on-error: true
       - name: Post / Update PR Quality Summary Comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check PR size
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({

--- a/src/config/navLinks.ts
+++ b/src/config/navLinks.ts
@@ -33,6 +33,7 @@ function withExternalMetadata(link: { href: string; label: string }): NavLink {
 }
 
 const navLinks: NavLink[] = navJson.links.map(withExternalMetadata);
+const navQuickLinks: NavLink[] = (navJson.quickLinks ?? []).map(withExternalMetadata);
 
 export default navLinks;
 
@@ -40,6 +41,10 @@ export const navConfig: NavConfig = {
   links: navLinks,
   socialLinks: (navJson.socialLinks ?? []).map(withExternalMetadata),
 };
+
+export function getNavQuickLinks(): NavLink[] {
+  return navQuickLinks;
+}
 
 export function getNavLinkByHref(href: string): NavLink | undefined {
   return navLinks.find((link) => link.href === href);

--- a/src/config/navSearchPages.ts
+++ b/src/config/navSearchPages.ts
@@ -1,7 +1,7 @@
 /**
  * Search index entries derived from navLinks — single source for page search results.
  */
-import navLinks from './navLinks';
+import navLinks, { getNavQuickLinks } from './navLinks';
 
 export type NavSearchPage = {
   type: 'page';
@@ -49,4 +49,24 @@ export function getNavSearchPages(): NavSearchPage[] {
       tags: meta.tags,
     };
   });
+}
+
+function toNavSearchPage(link: { href: string; label: string }): NavSearchPage {
+  const meta = PAGE_SEARCH_META[link.href] ?? {
+    description: link.label,
+    tags: [link.label.toLowerCase()],
+  };
+
+  return {
+    type: 'page',
+    title: link.label,
+    description: meta.description,
+    href: link.href,
+    tags: meta.tags,
+  };
+}
+
+/** Command Center quick links — sourced from nav.json `quickLinks`. */
+export function getNavQuickSearchPages(): NavSearchPage[] {
+  return getNavQuickLinks().map(toNavSearchPage);
 }

--- a/src/features/command-center/hooks/useCommandQuery.ts
+++ b/src/features/command-center/hooks/useCommandQuery.ts
@@ -79,9 +79,7 @@ export function useCommandQuery(isOpen: boolean) {
       if (!searchQuery.trim() && result.source === 'browse') {
         const featured = items.filter((item) => item.kind === 'project' && item.featured).slice(0, 3);
         const recent = items.filter((item) => item.kind === 'blog').slice(0, 3);
-        const quickHrefs = new Set(getNavQuickSearchPages().map((page) => page.href));
-        const quick = items.filter((item) => item.kind === 'page' && quickHrefs.has(item.href));
-        setGroups(buildBrowseGroups(featured, recent, quick.length ? quick : items.filter((i) => i.kind === 'page').slice(0, 3)));
+        setGroups(buildBrowseGroups(featured, recent, toQuickCommandItems()));
       } else {
         const enriched = enrichCommandItems(items, searchQuery);
         setGroups(groupCommandItems(enriched, searchCategory));

--- a/src/features/command-center/hooks/useCommandQuery.ts
+++ b/src/features/command-center/hooks/useCommandQuery.ts
@@ -8,7 +8,7 @@ import { enrichCommandItems } from '../lib/rankResults';
 import { parseCommandQuery } from '../lib/parseQuery';
 import { commandCenterEvents } from '../lib/analytics';
 import type { CommandGroup } from '../types';
-import { getNavSearchPages } from '../../../config/navSearchPages';
+import { getNavQuickSearchPages } from '../../../config/navSearchPages';
 
 const DEBOUNCE_MS = 150;
 const LOADING_DELAY_MS = 150;
@@ -19,24 +19,23 @@ function sourceFromResult(source: Awaited<ReturnType<typeof runSearch>>['source'
   return 'local';
 }
 
-function buildDefaultBrowse(): CommandGroup[] {
-  const pages = getNavSearchPages();
-  const quickLinks = pages
-    .filter((page) => ['/contact/', '/projects/', '/blog/'].includes(page.href))
-    .map((page) =>
-      toCommandItem(
-        {
-          type: 'page',
-          title: page.title,
-          description: page.description,
-          href: page.href,
-          tags: page.tags,
-        },
-        'curated',
-      ),
-    );
+function toQuickCommandItems() {
+  return getNavQuickSearchPages().map((page) =>
+    toCommandItem(
+      {
+        type: 'page',
+        title: page.title,
+        description: page.description,
+        href: page.href,
+        tags: page.tags,
+      },
+      'curated',
+    ),
+  );
+}
 
-  return buildBrowseGroups([], [], quickLinks);
+function buildDefaultBrowse(): CommandGroup[] {
+  return buildBrowseGroups([], [], toQuickCommandItems());
 }
 
 export function useCommandQuery(isOpen: boolean) {
@@ -80,7 +79,8 @@ export function useCommandQuery(isOpen: boolean) {
       if (!searchQuery.trim() && result.source === 'browse') {
         const featured = items.filter((item) => item.kind === 'project' && item.featured).slice(0, 3);
         const recent = items.filter((item) => item.kind === 'blog').slice(0, 3);
-        const quick = items.filter((item) => item.kind === 'page' && ['/contact/', '/projects/', '/blog/'].includes(item.href));
+        const quickHrefs = new Set(getNavQuickSearchPages().map((page) => page.href));
+        const quick = items.filter((item) => item.kind === 'page' && quickHrefs.has(item.href));
         setGroups(buildBrowseGroups(featured, recent, quick.length ? quick : items.filter((i) => i.kind === 'page').slice(0, 3)));
       } else {
         const enriched = enrichCommandItems(items, searchQuery);

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -13,7 +13,7 @@ import type { CollectionEntry } from 'astro:content';
  * Blog post from content collection
  * Represents a complete blog post with all metadata
  */
-export type BlogPost = CollectionEntry<'projects'>;
+export type BlogPost = CollectionEntry<'blog'>;
 
 /**
  * Project from content collection

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,47 +20,6 @@ export * from './components';
 export * from './api';
 
 // ============================================================================
-// Legacy Types (Kept for backward compatibility)
-// ============================================================================
-// NOTE: These types are deprecated but kept for backward compatibility.
-// All new code should use types from './content' and 'astro:content' instead.
-// Migration status: Most usages have been migrated. Remaining usages are
-// in legacy components that will be updated incrementally.
-
-/**
- * @deprecated Use CollectionEntry<'projects'> from 'astro:content' instead
- * @see src/types/content.ts for the new type system
- */
-export interface ProjectData {
-  slug: string;
-  data: {
-    title: string;
-    description: string;
-    date: Date;
-    tags: string[];
-    image?: string;
-    link?: string;
-    draft: boolean;
-  };
-}
-
-/**
- * @deprecated Use CollectionEntry<'blog'> from 'astro:content' instead
- * @see src/types/content.ts for the new type system
- */
-export interface BlogPost {
-  slug: string;
-  data: {
-    title: string;
-    description?: string;
-    pubDate: Date;
-    author?: string;
-    tags?: string[];
-    draft?: boolean;
-  };
-}
-
-// ============================================================================
 // Utility Types (Kept for general use)
 // ============================================================================
 

--- a/tests/vitest/navLinksSync.test.ts
+++ b/tests/vitest/navLinksSync.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import navLinks, { navConfig } from '../../src/config/navLinks';
+import navLinks, { getNavQuickLinks, navConfig } from '../../src/config/navLinks';
+import { getNavQuickSearchPages } from '../../src/config/navSearchPages';
 
 type NavJson = {
   links: Array<{ href: string; label: string }>;
+  quickLinks?: Array<{ href: string; label: string }>;
   socialLinks?: Array<{ href: string; label: string }>;
 };
 
@@ -23,6 +25,13 @@ describe('navLinks derived from nav.json', () => {
 
   it('loads primary links from nav.json', () => {
     expect(normalizeLinks(navLinks)).toEqual(normalizeLinks(navJson.links));
+  });
+
+  it('loads quick links from nav.json', () => {
+    expect(normalizeLinks(getNavQuickLinks())).toEqual(normalizeLinks(navJson.quickLinks ?? []));
+    expect(
+      getNavQuickSearchPages().map((page) => ({ href: page.href, label: page.title })),
+    ).toEqual(normalizeLinks(navJson.quickLinks ?? []));
   });
 
   it('applies external metadata to social links from nav.json', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 4 polish: type safety fixes, `nav.json` quickLinks wiring, and Dependabot housekeeping.

## Changes

### Type safety
- Fix `BlogPost` in `src/types/content.ts` — was incorrectly `CollectionEntry<'projects'>`, now `CollectionEntry<'blog'>`
- Remove unused legacy `ProjectData` / `BlogPost` interfaces from `src/types/index.ts` (superseded by `content.ts` + `astro:content`)
- `ProjectRow.astro` already uses `CollectionEntry<'projects'>` — no change needed

### Command Center quickLinks
- Export `getNavQuickLinks()` from `navLinks.ts` (reads `nav.json` `quickLinks`)
- Add `getNavQuickSearchPages()` in `navSearchPages.ts`
- `useCommandQuery` uses nav.json quick links instead of hardcoded `/contact/`, `/projects/`, `/blog/`
- Extended `navLinksSync.test.ts` coverage

### CI / Dependabot
- Bump `actions/github-script` v8 → v9 (supersedes #307)

## Validation
- `pnpm run typecheck` — pass
- `vitest run tests/vitest/navLinksSync.test.ts` — 4/4 pass

## Post-merge
Will close stale Dependabot PRs targeting superseded versions (Astro 5.x, Tailwind 4.2.x, etc.).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for quick navigation links in the command center, including matching quick search entries.
* **Bug Fixes**
  * Corrected blog content typing so blog posts are associated with the right content source.
  * Improved navigation behavior so quick links and browse results stay in sync with configuration.
* **Chores**
  * Updated workflow automation to a newer supported GitHub Actions script version.
* **Tests**
  * Expanded coverage for navigation configuration, including optional quick links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->