### PR TITLE
Fix wrangler token extraction in Cloudflare deploy setup

### DIFF
--- a/scripts/setup/github-cloudflare-deploy.sh
+++ b/scripts/setup/github-cloudflare-deploy.sh
@@ -28,7 +28,15 @@ if [[ "${1:-}" == "--from-wrangler" ]]; then
     echo "pnpm is required to read wrangler auth token"
     exit 1
   fi
-  TOKEN="$(pnpm exec wrangler auth token 2>/dev/null || true)"
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required to parse wrangler auth token output"
+    exit 1
+  fi
+  TOKEN="$(
+    pnpm exec wrangler auth token --json 2>/dev/null \
+      | python3 -c "import sys, json; raw = json.load(sys.stdin).get('token', ''); lines = [line.strip() for line in raw.splitlines() if line.strip()]; print(lines[-1] if lines else '')" \
+      || true
+  )"
   if [[ -z "$TOKEN" ]]; then
     echo "No wrangler auth token found. Run: pnpm exec wrangler login"
     exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The initial `CLOUDFLARE_API_TOKEN` secret was set with wrangler banner output (including the ⛅ emoji), which caused deploy failures:

```
The configured Cloudflare API token contains a character that cannot be used in an HTTP Authorization header: "⛅"
```

This updates `scripts/setup/github-cloudflare-deploy.sh` to parse `wrangler auth token --json` and extract only the last non-empty line (the actual token).

## Verification

- Re-set `CLOUDFLARE_API_TOKEN` with the cleaned token
- Manual `deploy-worker.yml` run succeeded: https://github.com/blakeox/blakeoxford.com/actions/runs/29050988903
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2794-1b71-70b0-a152-5920efb85636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

