### PR TITLE
feat(content): migrate home page copy to content collection

### DIFF
--- a/src/components/features/home/HomeCTASection.astro
+++ b/src/components/features/home/HomeCTASection.astro
@@ -2,18 +2,25 @@
 import Section from '../../primitives/Section.astro';
 import SectionHeading from '../../primitives/SectionHeading.astro';
 import Button from '../../primitives/Button.astro';
+import type { HomePageContent } from '../../../content/home/pageTypes';
+
+interface Props {
+  content: HomePageContent['cta'];
+}
+
+const { content } = Astro.props as Props;
 ---
 
 <Section padding="lg" container="xl" class="text-center">
   <div class="conversion-band mx-auto max-w-4xl">
     <div class="section-intro">
-      <span class="section-kicker">Next move</span>
-      <SectionHeading size="3xl">Bring the problem space. I&apos;ll help design the operating backbone.</SectionHeading>
+      <span class="section-kicker">{content.kicker}</span>
+      <SectionHeading size="3xl">{content.title}</SectionHeading>
       <p class="text-lg text-muted-foreground">
-        If you are evaluating a migration, automation program, reporting overhaul, or AI-enabled workflow, start with the highest-risk bottleneck and we can scope from there.
+        {content.description}
       </p>
       <div class="pt-2">
-        <Button variant="primary" href="/contact/">Start the conversation</Button>
+        <Button variant="primary" href={content.button.href}>{content.button.label}</Button>
       </div>
     </div>
   </div>

--- a/src/components/features/home/HomeHeroSection.astro
+++ b/src/components/features/home/HomeHeroSection.astro
@@ -4,14 +4,16 @@ import PageHero from '../../composites/PageHero.astro';
 import Button from '../../primitives/Button.astro';
 import ButtonGroup from '../../composites/ButtonGroup.astro';
 import FloatingEmoji from '../../primitives/FloatingEmoji.astro';
+import type { HomePageContent } from '../../../content/home/pageTypes';
 
 interface Props {
   author: string;
   tagline?: string;
   description?: string;
+  content: HomePageContent['hero'];
 }
 
-const { author, tagline, description } = Astro.props as Props;
+const { author, tagline, description, content } = Astro.props as Props;
 ---
 
 <PageHero id="about-me" class="hero-gradient-animated">
@@ -19,7 +21,7 @@ const { author, tagline, description } = Astro.props as Props;
     <div class="order-2 md:order-1">
       <div class="max-w-2xl space-y-8 text-base leading-relaxed text-foreground/85">
         <div class="space-y-5">
-          <span class="section-kicker">Systems architecture · automation · operating rigor</span>
+          <span class="section-kicker">{content.kicker}</span>
           <h1 class="font-heading text-4xl font-semibold tracking-tight text-foreground sm:text-5xl md:text-6xl lg:text-7xl">
             {author}
           </h1>
@@ -35,25 +37,22 @@ const { author, tagline, description } = Astro.props as Props;
           )}
         </div>
         <ul class="grid gap-3 text-sm text-foreground/88 sm:grid-cols-3 sm:text-base" role="list" aria-label="Selected strengths">
-          <li class="rounded-2xl border border-border/50 bg-surface/80 px-4 py-3">Enterprise migrations with adoption discipline</li>
-          <li class="rounded-2xl border border-border/50 bg-surface/80 px-4 py-3">Automation that reduces manual operational drag</li>
-          <li class="rounded-2xl border border-border/50 bg-surface/80 px-4 py-3">Analytics and controls built for decision-making</li>
+          {content.strengths.map((strength) => (
+            <li class="rounded-2xl border border-border/50 bg-surface/80 px-4 py-3">{strength}</li>
+          ))}
         </ul>
       </div>
       <ButtonGroup align="start" responsive class="mt-8">
         <Button
           variant="primary"
-          href="/contact/"
+          href={content.primaryCta.href}
           data-test="home-cta-connect"
           data-analytics="hero-cta"
         >
-          Start a conversation
+          {content.primaryCta.label}
         </Button>
-        <Button
-          variant="outline"
-          href="/projects/"
-        >
-          Review selected projects
+        <Button variant="outline" href={content.secondaryCta.href}>
+          {content.secondaryCta.label}
         </Button>
       </ButtonGroup>
     </div>
@@ -62,17 +61,17 @@ const { author, tagline, description } = Astro.props as Props;
         <div class="absolute -inset-4 rounded-full bg-gradient-to-r from-accent/30 to-primary/30 blur-xl opacity-70 animate-pulse"></div>
         <div class="relative rounded-full bg-gradient-to-r from-accent to-primary p-1">
           <CoinFlipImage
-            frontSrc="/assets/images/Blake-O-scaled.jpg"
-            backSrc="/assets/images/china-profile-picture.jpg"
-            alt="Blake Oxford"
-            altBack="Blake Oxford in China"
+            frontSrc={content.portrait.frontSrc}
+            backSrc={content.portrait.backSrc}
+            alt={content.portrait.alt}
+            altBack={content.portrait.altBack}
             size={280}
             flipMultipleTimes
             loading="eager"
             fetchPriority="high"
             decoding="auto"
             role="img"
-            aria-label="Photo of Blake Oxford"
+            aria-label={`Photo of ${content.portrait.alt}`}
           />
         </div>
         <FloatingEmoji emoji="💡" position="top-right" size="md" />

--- a/src/components/features/home/HomeLatestPostsSection.astro
+++ b/src/components/features/home/HomeLatestPostsSection.astro
@@ -4,20 +4,22 @@ import Section from '../../primitives/Section.astro';
 import SectionHeading from '../../primitives/SectionHeading.astro';
 import Button from '../../primitives/Button.astro';
 import BlogPostCard from '../blog/BlogPostCard.astro';
+import type { HomePageContent } from '../../../content/home/pageTypes';
 
 interface Props {
   posts: CollectionEntry<'blog'>[];
+  content: HomePageContent['latestPosts'];
 }
 
-const { posts } = Astro.props as Props;
+const { posts, content } = Astro.props as Props;
 ---
 
 <Section padding="lg" container="xl" background="gradient" class="text-center" aria-labelledby="latest-blog-posts">
   <div class="section-intro mb-12">
-    <span class="section-kicker">Writing</span>
-    <SectionHeading id="latest-blog-posts" size="4xl">Practical notes from the field</SectionHeading>
+    <span class="section-kicker">{content.kicker}</span>
+    <SectionHeading id="latest-blog-posts" size="4xl">{content.title}</SectionHeading>
     <p class="text-lg text-muted-foreground">
-      Essays and case-backed observations on automation, analytics, governance, and operational improvement.
+      {content.description}
     </p>
   </div>
   <ul class="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3" role="list">
@@ -30,12 +32,12 @@ const { posts } = Astro.props as Props;
     ) : (
       <li class="rounded-2xl border border-dashed border-border/40 bg-background/90 p-6 text-center shadow-md">
         <p class="text-sm text-muted-foreground">
-          Blog posts are on the way-check back soon for new case studies and playbooks.
+          {content.emptyMessage}
         </p>
       </li>
     )}
   </ul>
   <div class="mt-8 text-center">
-    <Button variant="outline" href="/blog/">View all writing</Button>
+    <Button variant="outline" href={content.cta.href}>{content.cta.label}</Button>
   </div>
 </Section>

--- a/src/components/features/home/HomeRecentProjectsSection.astro
+++ b/src/components/features/home/HomeRecentProjectsSection.astro
@@ -5,20 +5,22 @@ import SectionHeading from '../../primitives/SectionHeading.astro';
 import Grid from '../../primitives/Grid.astro';
 import Button from '../../primitives/Button.astro';
 import ProjectCard from '../projects/ProjectCard.astro';
+import type { HomePageContent } from '../../../content/home/pageTypes';
 
 interface Props {
   projects: CollectionEntry<'projects'>[];
+  content: HomePageContent['recentProjects'];
 }
 
-const { projects } = Astro.props as Props;
+const { projects, content } = Astro.props as Props;
 ---
 
 <Section id="recent-projects" padding="lg" container="xl" aria-labelledby="recent-projects-title">
   <div class="section-intro mb-12">
-    <span class="section-kicker">Selected projects</span>
-    <SectionHeading id="recent-projects-title" size="4xl">Work that shipped with measurable impact</SectionHeading>
+    <span class="section-kicker">{content.kicker}</span>
+    <SectionHeading id="recent-projects-title" size="4xl">{content.title}</SectionHeading>
     <p class="text-lg text-muted-foreground">
-      A cross-section of systems, automation, and analytics engagements built to survive real operating conditions.
+      {content.description}
     </p>
   </div>
   <Grid cols="3" gap="lg">
@@ -27,6 +29,6 @@ const { projects } = Astro.props as Props;
     ))}
   </Grid>
   <div class="mt-8 text-center">
-    <Button variant="outline" href="/projects/">View all case studies</Button>
+    <Button variant="outline" href={content.cta.href}>{content.cta.label}</Button>
   </div>
 </Section>

--- a/src/components/features/home/HomeResumeHighlightsSection.astro
+++ b/src/components/features/home/HomeResumeHighlightsSection.astro
@@ -3,47 +3,37 @@ import Section from '../../primitives/Section.astro';
 import Grid from '../../primitives/Grid.astro';
 import ResumeHighlightCard from './ResumeHighlightCard.astro';
 import ResumeHighlightItem from './ResumeHighlightItem.astro';
+import ResumeHighlightIcon from './ResumeHighlightIcon.astro';
+import type { HomePageContent } from '../../../content/home/pageTypes';
+
+interface Props {
+  content: HomePageContent['resumeHighlights'];
+}
+
+const { content } = Astro.props as Props;
 ---
 
 <Section id="resume-highlights" padding="lg" container="lg">
   <div class="space-y-12">
     <div class="section-intro">
-      <span class="section-kicker">Selected outcomes</span>
-      <h2 class="font-heading text-3xl font-semibold text-foreground sm:text-4xl md:text-5xl">Proof from enterprise transformation work</h2>
+      <span class="section-kicker">{content.kicker}</span>
+      <h2 class="font-heading text-3xl font-semibold text-foreground sm:text-4xl md:text-5xl">{content.title}</h2>
       <p class="mx-auto max-w-3xl text-lg text-muted-foreground">
-        Representative operating wins across migration, automation, analytics, and workflow control design.
+        {content.description}
       </p>
     </div>
     <Grid cols="3" gap="lg" alignItems="stretch">
-      <ResumeHighlightCard title="Cloud &amp; SaaS Transformations" description="Complex platform rollouts delivered end-to-end with strong adoption and governance controls.">
-        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-on-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />
-        </svg>
-        <ResumeHighlightItem><svg slot="icon" class="h-4.5 w-4.5 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>Google Workspace → Microsoft 365 migration for 180 users</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4.5 w-4.5 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>Sage Intacct financial platform implementation</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4.5 w-4.5 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" /></svg>Azure/Intune endpoint management deployment</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4.5 w-4.5 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" /></svg>ADP Workforce Now and Cornerstone LMS integration</ResumeHighlightItem>
-      </ResumeHighlightCard>
-
-      <ResumeHighlightCard title="Automation &amp; Savings" description="Multi-million-dollar overhead reduction via coordinated automation, analytics, and consolidation initiatives.">
-        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-on-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-        </svg>
-        <ResumeHighlightItem><svg slot="icon" class="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>Azure cloud infrastructure optimization</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>Power BI analytics and real-time dashboarding</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>Custom OpenAI workflow integrations</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>Enterprise system consolidations and integrations</ResumeHighlightItem>
-      </ResumeHighlightCard>
-
-      <ResumeHighlightCard title="Data Analytics" description="Comprehensive business intelligence solutions that keep decision-makers informed in real time.">
-        <svg slot="icon" xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-on-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-        </svg>
-        <ResumeHighlightItem><svg slot="icon" class="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zM14 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z" /></svg>Real-time SQL/Power BI dashboards</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>Predictive financial modeling systems</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" /></svg>C-suite executive decision support frameworks</ResumeHighlightItem>
-        <ResumeHighlightItem><svg slot="icon" class="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" /></svg>Automated KPI tracking and performance visualization</ResumeHighlightItem>
-      </ResumeHighlightCard>
+      {content.cards.map((card) => (
+        <ResumeHighlightCard title={card.title} description={card.description}>
+          <ResumeHighlightIcon slot="icon" name={card.icon} variant="card" />
+          {card.items.map((item) => (
+            <ResumeHighlightItem>
+              <ResumeHighlightIcon slot="icon" name={item.icon} />
+              {item.text}
+            </ResumeHighlightItem>
+          ))}
+        </ResumeHighlightCard>
+      ))}
     </Grid>
   </div>
 </Section>

--- a/src/components/features/home/ResumeHighlightIcon.astro
+++ b/src/components/features/home/ResumeHighlightIcon.astro
@@ -1,0 +1,94 @@
+---
+import type { HomeResumeHighlightCard, HomeResumeHighlightItem } from '../../../content/home/pageTypes';
+
+interface Props {
+  name: HomeResumeHighlightCard['icon'] | HomeResumeHighlightItem['icon'];
+  variant?: 'card' | 'item';
+}
+
+const { name, variant = 'item' } = Astro.props as Props;
+
+const cardClass = 'h-6 w-6 text-on-primary';
+const itemClass = variant === 'item' ? 'h-4 w-4 text-accent' : 'h-4.5 w-4.5 text-accent';
+const className = variant === 'card' ? cardClass : itemClass;
+---
+
+{name === 'cloud' && (
+  <svg xmlns="http://www.w3.org/2000/svg" class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />
+  </svg>
+)}
+{name === 'automation' && (
+  <svg xmlns="http://www.w3.org/2000/svg" class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
+  </svg>
+)}
+{name === 'analytics' && (
+  <svg xmlns="http://www.w3.org/2000/svg" class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+  </svg>
+)}
+{name === 'migrate' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+  </svg>
+)}
+{name === 'money' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+)}
+{name === 'cloud-plus' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />
+  </svg>
+)}
+{name === 'chat' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+  </svg>
+)}
+{name === 'azure-opt' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+  </svg>
+)}
+{name === 'chart' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+  </svg>
+)}
+{name === 'lightbulb' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+  </svg>
+)}
+{name === 'consolidate' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+  </svg>
+)}
+{name === 'grid' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zM14 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z" />
+  </svg>
+)}
+{name === 'predictive' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+  </svg>
+)}
+{name === 'shield' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+  </svg>
+)}
+{name === 'trend' && (
+  <svg class={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+  </svg>
+)}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -93,6 +93,36 @@ const contactChannelSchema = z.object({
   label: z.string(),
 });
 
+const ctaLinkSchema = z.object({
+  href: z.string(),
+  label: z.string(),
+});
+
+const homeResumeHighlightItemSchema = z.object({
+  icon: z.enum([
+    'migrate',
+    'money',
+    'cloud-plus',
+    'chat',
+    'azure-opt',
+    'chart',
+    'lightbulb',
+    'consolidate',
+    'grid',
+    'predictive',
+    'shield',
+    'trend',
+  ]),
+  text: z.string(),
+});
+
+const homeResumeHighlightCardSchema = z.object({
+  icon: z.enum(['cloud', 'automation', 'analytics']),
+  title: z.string(),
+  description: z.string(),
+  items: z.array(homeResumeHighlightItemSchema),
+});
+
 // About page content
 const about = defineCollection({
   loader: glob({ pattern: 'page.json', base: './src/content/about' }),
@@ -172,6 +202,60 @@ const contact = defineCollection({
   }),
 });
 
+// Home page content
+const home = defineCollection({
+  loader: glob({ pattern: 'page.json', base: './src/content/home' }),
+  schema: z.object({
+    meta: z.object({
+      title: z.string(),
+      description: z.string(),
+    }),
+    hero: z.object({
+      kicker: z.string(),
+      defaultTagline: z.string(),
+      strengths: z.array(z.string()),
+      primaryCta: ctaLinkSchema,
+      secondaryCta: ctaLinkSchema,
+      portrait: z.object({
+        frontSrc: z.string(),
+        backSrc: z.string(),
+        alt: z.string(),
+        altBack: z.string(),
+      }),
+    }),
+    technologies: z.object({
+      kicker: z.string(),
+      title: z.string(),
+      description: z.string(),
+    }),
+    resumeHighlights: z.object({
+      kicker: z.string(),
+      title: z.string(),
+      description: z.string(),
+      cards: z.array(homeResumeHighlightCardSchema),
+    }),
+    recentProjects: z.object({
+      kicker: z.string(),
+      title: z.string(),
+      description: z.string(),
+      cta: ctaLinkSchema,
+    }),
+    latestPosts: z.object({
+      kicker: z.string(),
+      title: z.string(),
+      description: z.string(),
+      emptyMessage: z.string(),
+      cta: ctaLinkSchema,
+    }),
+    cta: z.object({
+      kicker: z.string(),
+      title: z.string(),
+      description: z.string(),
+      button: ctaLinkSchema,
+    }),
+  }),
+});
+
 // Navigation collection schema
 const navigation = defineCollection({
   loader: glob({ pattern: '**/*.json', base: './src/content/navigation' }),
@@ -184,4 +268,4 @@ const navigation = defineCollection({
   }),
 });
 
-export const collections = { blog, projects, about, contact, navigation };
+export const collections = { blog, projects, about, contact, home, navigation };

--- a/src/content/home/getHomePage.ts
+++ b/src/content/home/getHomePage.ts
@@ -1,0 +1,10 @@
+import { getEntry } from 'astro:content';
+import type { HomePageContent } from './pageTypes';
+
+export async function getHomePage(): Promise<HomePageContent> {
+  const entry = await getEntry('home', 'page');
+  if (!entry) {
+    throw new Error('Home page content not found at src/content/home/page.json');
+  }
+  return entry.data as HomePageContent;
+}

--- a/src/content/home/page.json
+++ b/src/content/home/page.json
@@ -1,0 +1,87 @@
+{
+  "meta": {
+    "title": "Blake Oxford - Leadership & Portfolio",
+    "description": "Systems architect and workflow strategist turning complexity into opportunity-designing scalable systems, streamlining operations, and leading high-stakes transformations that deliver lasting results."
+  },
+  "hero": {
+    "kicker": "Systems architecture · automation · operating rigor",
+    "defaultTagline": "Systems Architect · Workflow Strategist · Operational Improvement Leader",
+    "strengths": [
+      "Enterprise migrations with adoption discipline",
+      "Automation that reduces manual operational drag",
+      "Analytics and controls built for decision-making"
+    ],
+    "primaryCta": { "href": "/contact/", "label": "Start a conversation" },
+    "secondaryCta": { "href": "/projects/", "label": "Review selected projects" },
+    "portrait": {
+      "frontSrc": "/assets/images/Blake-O-scaled.jpg",
+      "backSrc": "/assets/images/china-profile-picture.jpg",
+      "alt": "Blake Oxford",
+      "altBack": "Blake Oxford in China"
+    }
+  },
+  "technologies": {
+    "kicker": "Delivery stack",
+    "title": "Platforms and tools used in delivery",
+    "description": "A representative toolset behind architecture, workflow automation, analytics, and cloud delivery work."
+  },
+  "resumeHighlights": {
+    "kicker": "Selected outcomes",
+    "title": "Proof from enterprise transformation work",
+    "description": "Representative operating wins across migration, automation, analytics, and workflow control design.",
+    "cards": [
+      {
+        "icon": "cloud",
+        "title": "Cloud & SaaS Transformations",
+        "description": "Complex platform rollouts delivered end-to-end with strong adoption and governance controls.",
+        "items": [
+          { "icon": "migrate", "text": "Google Workspace → Microsoft 365 migration for 180 users" },
+          { "icon": "money", "text": "Sage Intacct financial platform implementation" },
+          { "icon": "cloud-plus", "text": "Azure/Intune endpoint management deployment" },
+          { "icon": "chat", "text": "ADP Workforce Now and Cornerstone LMS integration" }
+        ]
+      },
+      {
+        "icon": "automation",
+        "title": "Automation & Savings",
+        "description": "Multi-million-dollar overhead reduction via coordinated automation, analytics, and consolidation initiatives.",
+        "items": [
+          { "icon": "azure-opt", "text": "Azure cloud infrastructure optimization" },
+          { "icon": "chart", "text": "Power BI analytics and real-time dashboarding" },
+          { "icon": "lightbulb", "text": "Custom OpenAI workflow integrations" },
+          { "icon": "consolidate", "text": "Enterprise system consolidations and integrations" }
+        ]
+      },
+      {
+        "icon": "analytics",
+        "title": "Data Analytics",
+        "description": "Comprehensive business intelligence solutions that keep decision-makers informed in real time.",
+        "items": [
+          { "icon": "grid", "text": "Real-time SQL/Power BI dashboards" },
+          { "icon": "predictive", "text": "Predictive financial modeling systems" },
+          { "icon": "shield", "text": "C-suite executive decision support frameworks" },
+          { "icon": "trend", "text": "Automated KPI tracking and performance visualization" }
+        ]
+      }
+    ]
+  },
+  "recentProjects": {
+    "kicker": "Selected projects",
+    "title": "Work that shipped with measurable impact",
+    "description": "A cross-section of systems, automation, and analytics engagements built to survive real operating conditions.",
+    "cta": { "href": "/projects/", "label": "View all case studies" }
+  },
+  "latestPosts": {
+    "kicker": "Writing",
+    "title": "Practical notes from the field",
+    "description": "Essays and case-backed observations on automation, analytics, governance, and operational improvement.",
+    "emptyMessage": "Blog posts are on the way-check back soon for new case studies and playbooks.",
+    "cta": { "href": "/blog/", "label": "View all writing" }
+  },
+  "cta": {
+    "kicker": "Next move",
+    "title": "Bring the problem space. I'll help design the operating backbone.",
+    "description": "If you are evaluating a migration, automation program, reporting overhaul, or AI-enabled workflow, start with the highest-risk bottleneck and we can scope from there.",
+    "button": { "href": "/contact/", "label": "Start the conversation" }
+  }
+}

--- a/src/content/home/pageTypes.ts
+++ b/src/content/home/pageTypes.ts
@@ -1,0 +1,78 @@
+export type HomeCtaLink = {
+  href: string;
+  label: string;
+};
+
+export type HomeResumeHighlightItem = {
+  icon:
+    | 'migrate'
+    | 'money'
+    | 'cloud-plus'
+    | 'chat'
+    | 'azure-opt'
+    | 'chart'
+    | 'lightbulb'
+    | 'consolidate'
+    | 'grid'
+    | 'predictive'
+    | 'shield'
+    | 'trend';
+  text: string;
+};
+
+export type HomeResumeHighlightCard = {
+  icon: 'cloud' | 'automation' | 'analytics';
+  title: string;
+  description: string;
+  items: HomeResumeHighlightItem[];
+};
+
+export type HomePageContent = {
+  meta: {
+    title: string;
+    description: string;
+  };
+  hero: {
+    kicker: string;
+    defaultTagline: string;
+    strengths: string[];
+    primaryCta: HomeCtaLink;
+    secondaryCta: HomeCtaLink;
+    portrait: {
+      frontSrc: string;
+      backSrc: string;
+      alt: string;
+      altBack: string;
+    };
+  };
+  technologies: {
+    kicker: string;
+    title: string;
+    description: string;
+  };
+  resumeHighlights: {
+    kicker: string;
+    title: string;
+    description: string;
+    cards: HomeResumeHighlightCard[];
+  };
+  recentProjects: {
+    kicker: string;
+    title: string;
+    description: string;
+    cta: HomeCtaLink;
+  };
+  latestPosts: {
+    kicker: string;
+    title: string;
+    description: string;
+    emptyMessage: string;
+    cta: HomeCtaLink;
+  };
+  cta: {
+    kicker: string;
+    title: string;
+    description: string;
+    button: HomeCtaLink;
+  };
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,8 +12,11 @@ import HomeLatestPostsSection from '../components/features/home/HomeLatestPostsS
 import HomeCTASection from '../components/features/home/HomeCTASection.astro';
 import TechnologyItem from '../components/features/home/TechnologyItem.astro';
 import { getProjectsSorted } from '../content/projects/getProjects';
+import { getHomePage } from '../content/home/getHomePage';
 import { technologies, siteConfig } from '../config/data';
 import { take } from '../utils/index.js';
+
+const page = await getHomePage();
 
 const allBlogPosts: CollectionEntry<'blog'>[] = await getCollection('blog');
 const blogPosts = allBlogPosts
@@ -28,9 +31,8 @@ const heroDescription: string | undefined = siteConfig?.tagline;
 const heroTagline: string | undefined = siteConfig?.description;
 const normalize = (s?: string) => (s ?? '').replace(/\s+/g, ' ').trim().toLowerCase();
 const shouldShowTagline = normalize(heroTagline) !== '' && normalize(heroTagline) !== normalize(heroDescription);
-const defaultTagline = 'Systems Architect · Workflow Strategist · Operational Improvement Leader';
 const taglineToShow: string | undefined = normalize(heroTagline) === ''
-  ? defaultTagline
+  ? page.hero.defaultTagline
   : (shouldShowTagline ? heroTagline : undefined);
 
 function deriveImageData(imgPath?: string) {
@@ -46,7 +48,7 @@ function deriveImageData(imgPath?: string) {
 }
 ---
 
-<Layout title="Blake Oxford - Leadership & Portfolio" description="Systems architect and workflow strategist turning complexity into opportunity-designing scalable systems, streamlining operations, and leading high-stakes transformations that deliver lasting results." wide={true}>
+<Layout title={page.meta.title} description={page.meta.description} wide={true}>
   <link slot="head" rel="preload" as="image" href="/assets/images/optimized/avif/Blake-O-scaled@640w.avif" type="image/avif" fetchpriority="high" />
   <div class="fixed inset-0 -z-10 pointer-events-none">
     <FloatingBlur size="xl" color="accent" position="top-left" translate="-translate-x-1/2 -translate-y-1/2" />
@@ -54,15 +56,20 @@ function deriveImageData(imgPath?: string) {
   </div>
 
   <div class="space-y-16 sm:space-y-20 lg:space-y-24">
-    <HomeHeroSection author={siteConfig.author} tagline={taglineToShow} description={heroDescription} />
-    <HomeResumeHighlightsSection />
+    <HomeHeroSection
+      author={siteConfig.author}
+      tagline={taglineToShow}
+      description={heroDescription}
+      content={page.hero}
+    />
+    <HomeResumeHighlightsSection content={page.resumeHighlights} />
 
     <section id="technologies" class="page-slab w-full py-16 text-center">
       <div class="section-intro mb-10">
-        <span class="section-kicker">Delivery stack</span>
-        <SectionHeading size="4xl">Platforms and tools used in delivery</SectionHeading>
+        <span class="section-kicker">{page.technologies.kicker}</span>
+        <SectionHeading size="4xl">{page.technologies.title}</SectionHeading>
         <p class="text-lg text-muted-foreground">
-          A representative toolset behind architecture, workflow automation, analytics, and cloud delivery work.
+          {page.technologies.description}
         </p>
       </div>
       <ul class="flex flex-wrap justify-center gap-8 text-lg font-medium text-foreground/85">
@@ -76,8 +83,8 @@ function deriveImageData(imgPath?: string) {
       </ul>
     </section>
 
-    <HomeRecentProjectsSection projects={recentProjects} />
-    <HomeLatestPostsSection posts={recentBlogPosts} />
-    <HomeCTASection />
+    <HomeRecentProjectsSection projects={recentProjects} content={page.recentProjects} />
+    <HomeLatestPostsSection posts={recentBlogPosts} content={page.latestPosts} />
+    <HomeCTASection content={page.cta} />
   </div>
 </Layout>

--- a/tests/vitest/pageContent.test.ts
+++ b/tests/vitest/pageContent.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-describe('About and Contact page content', () => {
+describe('About, Contact, and Home page content', () => {
   it('about page.json includes required sections', () => {
     const about = JSON.parse(
       readFileSync(path.join(process.cwd(), 'src/content/about/page.json'), 'utf8'),
@@ -24,5 +24,17 @@ describe('About and Contact page content', () => {
     expect(contact.hero.scenarios.length).toBe(3);
     expect(contact.channels.items.length).toBeGreaterThan(0);
     expect(contact.channels.items.some((item: { icon: string }) => item.icon === 'email')).toBe(true);
+  });
+
+  it('home page.json includes hero, highlights, and section copy', () => {
+    const home = JSON.parse(
+      readFileSync(path.join(process.cwd(), 'src/content/home/page.json'), 'utf8'),
+    );
+
+    expect(home.meta.title).toBeTruthy();
+    expect(home.hero.strengths.length).toBe(3);
+    expect(home.resumeHighlights.cards.length).toBe(3);
+    expect(home.recentProjects.cta.href).toBe('/projects/');
+    expect(home.cta.button.href).toBe('/contact/');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates home page marketing copy into a content collection, matching the about/contact pattern from the design system audit.

- Adds `src/content/home/page.json` with hero, resume highlights, technologies intro, projects/posts sections, and CTA copy
- Adds `getHomePage()` helper, Zod schema, and TypeScript types
- Updates home section components to accept `content` props
- Extracts resume highlight SVG icons into `ResumeHighlightIcon.astro`
- Technology stack logos remain in `config/data.ts` (require Astro asset imports)

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test -- --run` (640 tests)
- [x] `pnpm test:e2e:visual:chromium` (10/10, home snapshot unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c52-e100-70ea-90cf-7639c03dd5b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c52-e100-70ea-90cf-7639c03dd5b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

