### PR TITLE
Strip design-system residue and enforce typeScale policy

### DIFF
--- a/.github/instructions/design.instructions.md
+++ b/.github/instructions/design.instructions.md
@@ -39,10 +39,14 @@ Compose class lists with `cn()` from `src/utils/cn.ts` in primitives.
 - Fonts: `--font-sans` (Source Sans 3), `--font-heading` (Space Grotesk), `--font-mono`
 - Utilities: `font-sans`, `font-heading`, `text-xxs`, `tracking-label`, `tracking-smallcaps`
 - Heading ladder: `src/lib/typeScale.ts` — `identity` | `hero` | `display` | `section` | `title` | `subtitle` (shared by `IntroCopy` and `SectionHeading`; `xl`–`5xl` aliases map to the ladder)
+- Do not hand-roll `font-heading` + `text-2xl+` ladders in features — `design:lint` flags them
 
 ### Spacing, radius, shadows, motion
 
 - Spacing: Tailwind default scale for local gaps; section rhythm via `--space-section-*` → `py-section-*` on `Section`
+- Cards: elevated surfaces go through `BaseCard` (not DIY `rounded-3xl` + `shadow-lg`)
+- Badges: `Badge variant="pill"` — do not import `BadgePill` in new code
+- Atmosphere: no decorative blur orbs outside `PageHero` `includeBlurOrbs` (default off)
 - Radius: `rounded-sm` … `rounded-2xl` from `--radius-*`
 - Shadows: `shadow-sm` … `shadow-2xl`, plus `shadow-overlay` for modal panels
 - Motion: `duration-fast` (100ms), `duration-normal` (200ms), `duration-moderate` (300ms), `duration-slow` (500ms)

--- a/DESIGN_BEST_PRACTICES.md
+++ b/DESIGN_BEST_PRACTICES.md
@@ -60,7 +60,9 @@ Article/MDX body: wrap with `Prose` (`src/components/primitives/Prose.astro`). T
 
 Live token docs at `/design/tokens` auto-list public utilities by parsing `@theme inline` via `src/lib/designTokens.ts`, and show browser-resolved values plus live WCAG contrast pairs.
 
-Heading sizes: use the shared ladder in `src/lib/typeScale.ts` (`identity` → `hero` → `display` → `section` → `title` → `subtitle`) via `IntroCopy` / `SectionHeading`. Section vertical padding uses `--space-section-*` / `py-section-*`. Prefer Tailwind’s default spacing scale for local gaps and padding.
+Heading sizes: use the shared ladder in `src/lib/typeScale.ts` (`identity` → `hero` → `display` → `section` → `title` → `subtitle`) via `IntroCopy` / `SectionHeading` / `headingSizeClass()`. Section vertical padding uses `--space-section-*` / `py-section-*`. Prefer Tailwind’s default spacing scale for local gaps and padding.
+
+`design:lint` also enforces: no decorative blur orbs outside `PageHero`’s opt-in; no `BadgePill` imports (use `Badge variant="pill"`); no DIY elevated card shells when `BaseCard` is available; no ad-hoc `font-heading` + `text-2xl+` ladders outside the typeScale allowlist.
 
 ### Guidelines
 

--- a/scripts/quality/design-lint.js
+++ b/scripts/quality/design-lint.js
@@ -15,6 +15,10 @@
  * - no hard-coded high elevation in primitives/composites
  * - no legacy shell escape patterns
  * - no direct Tailwind container shell usage in app surfaces
+ * - no decorative blur orbs outside PageHero opt-in
+ * - no BadgePill imports (use Badge variant="pill")
+ * - no DIY elevated card shells when BaseCard is available
+ * - no ad-hoc font-heading size ladders outside typeScale allowlist
  */
 import fs from 'fs';
 import path from 'path';
@@ -71,9 +75,43 @@ const COMPONENT_DOC_ENTRY_REGEX =
   /^  {\s*\n\s{4}name:\s*'([^']+)'[\s\S]*?\n\s{4}category:\s*'([^']+)'[\s\S]*?\n\s{4}filePath:\s*'([^']+)'/gm;
 const STALE_DECORATIVE_DOC_REGEX =
   /glass-morphism|glass morphism|Frosted Glass|Rotating Gradient|Pulse Scale|Continuous gradient|shadow animations|gradient overlay/g;
+/** Decorative blur orbs / washes (rounded-full + heavy blur). */
+const BLUR_ORB_REGEX =
+  /(?:rounded-full[^\n"'`]{0,100}blur-(?:2xl|3xl)|blur-(?:2xl|3xl)[^\n"'`]{0,100}rounded-full)/g;
+/** Prefer Badge variant="pill" — BadgePill is a deprecated thin wrapper. */
+const BADGE_PILL_IMPORT_REGEX =
+  /\bimport\s+BadgePill\b|from\s+['"][^'"]*BadgePill(?:\.astro)?['"]/g;
+/** Elevated DIY cards that should use BaseCard. */
+const DIY_ELEVATED_CARD_REGEX =
+  /(?:rounded-(?:2xl|3xl)[^\n"'`]{0,160}shadow-(?:md|lg)|shadow-(?:md|lg)[^\n"'`]{0,160}rounded-(?:2xl|3xl))/g;
+/** Ad-hoc heading ladders (2xl+) — prefer headingSizeClass / IntroCopy / SectionHeading. */
+const RAW_HEADING_LADDER_REGEX =
+  /font-heading[^\n"'`]{0,160}\b(?:sm:|md:|lg:|xl:)?text-(?:[2-7]xl)\b|\b(?:sm:|md:|lg:|xl:)?text-(?:[2-7]xl)\b[^\n"'`]{0,160}font-heading/g;
 
 const allowedPx = new Set([0, 1, 2, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48, 56, 64]);
 const allowedComponentRootFiles = new Set(['src/components/index.ts']);
+
+/** Opt-in blur orbs only on PageHero (includeBlurOrbs). */
+const blurOrbAllowPaths = new Set(['src/components/composites/PageHero.astro']);
+
+const badgePillAllowPaths = new Set([
+  'src/components/primitives/BadgePill.astro',
+  'src/components/primitives/index.ts',
+  'tests/vitest/primitives.test.ts',
+]);
+
+const diyElevatedAllowPaths = new Set([
+  'src/components/primitives/BaseCard.astro',
+  'src/components/composites/FeatureCard.astro',
+  'src/components/composites/PhotoCarousel.astro',
+]);
+
+const headingLadderAllowPaths = new Set([
+  'src/lib/typeScale.ts',
+  'src/components/composites/IntroCopy.astro',
+  'src/components/primitives/SectionHeading.astro',
+  'src/components/primitives/Prose.astro',
+]);
 
 const reusableSurfacePaths = [
   'src/components',
@@ -114,6 +152,10 @@ const findings = {
   shell: [],
   gutter: [],
   container: [],
+  blurOrb: [],
+  badgePill: [],
+  diyCard: [],
+  headingLadder: [],
 };
 
 function shouldIgnoreDir(name) {
@@ -288,6 +330,38 @@ function scanSourceFile(file) {
   }
 
   if (
+    (relPath.startsWith('src/components/') ||
+      relPath.startsWith('src/content/blog/') ||
+      relPath.startsWith('src/pages/')) &&
+    !blurOrbAllowPaths.has(relPath)
+  ) {
+    addRegexFindings(findings.blurOrb, relPath, content, BLUR_ORB_REGEX);
+  }
+
+  if (!badgePillAllowPaths.has(relPath)) {
+    addRegexFindings(findings.badgePill, relPath, content, BADGE_PILL_IMPORT_REGEX);
+  }
+
+  if (
+    (relPath.startsWith('src/components/features/') ||
+      relPath.startsWith('src/components/composites/')) &&
+    !diyElevatedAllowPaths.has(relPath) &&
+    !content.includes('BaseCard')
+  ) {
+    addRegexFindings(findings.diyCard, relPath, content, DIY_ELEVATED_CARD_REGEX);
+  }
+
+  if (
+    (relPath.startsWith('src/components/') || relPath.startsWith('src/pages/')) &&
+    !relPath.startsWith('src/pages/design/') &&
+    !relPath.startsWith('src/pages/docs/') &&
+    !relPath.startsWith('src/pages/debug/') &&
+    !headingLadderAllowPaths.has(relPath)
+  ) {
+    addRegexFindings(findings.headingLadder, relPath, content, RAW_HEADING_LADDER_REGEX);
+  }
+
+  if (
     (relPath.startsWith('src/pages/') || relPath.startsWith('src/components/')) &&
     !relPath.startsWith('src/pages/design/') &&
     !relPath.startsWith('src/pages/docs/') &&
@@ -346,6 +420,16 @@ if (isDirectRun) {
     findings.gutter
   );
   printFindings('Direct container shell usage detected', findings.container);
+  printFindings(
+    'Decorative blur orbs detected (use PageHero includeBlurOrbs or remove)',
+    findings.blurOrb
+  );
+  printFindings('BadgePill imports detected (use Badge variant="pill")', findings.badgePill);
+  printFindings('DIY elevated card shells detected (prefer BaseCard)', findings.diyCard);
+  printFindings(
+    'Ad-hoc heading ladders detected (use typeScale / IntroCopy / SectionHeading)',
+    findings.headingLadder
+  );
 
   const issueCount = Object.values(findings).reduce((count, list) => count + list.length, 0);
 

--- a/src/components/composites/CTASection.astro
+++ b/src/components/composites/CTASection.astro
@@ -4,6 +4,7 @@
  */
 import Button from '../primitives/Button.astro';
 import ButtonGroup from '../composites/ButtonGroup.astro';
+import { headingSizeClass } from '../../lib/typeScale';
 
 interface Props {
   heading: string;
@@ -25,7 +26,12 @@ const {
 ---
 
 <div class="flex max-w-2xl flex-col gap-5">
-  <h3 class="font-heading text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+  <h3
+    class:list={[
+      'font-heading font-semibold tracking-tight text-foreground',
+      headingSizeClass('title'),
+    ]}
+  >
     {heading}
   </h3>
   <p class="text-base leading-relaxed text-muted-foreground sm:text-lg">

--- a/src/components/composites/EditorialList.astro
+++ b/src/components/composites/EditorialList.astro
@@ -7,6 +7,8 @@
  * - kickerAside → short kickers (years) in a left column
  * - otherwise → long kickers (metrics) stack above the title
  */
+import { headingSizeClass } from '../../lib/typeScale';
+
 export type EditorialRow = {
   /** Accent lead line (metric, year, etc.) */
   kicker?: string;
@@ -82,7 +84,12 @@ const Tag = listAs ?? (numbered ? 'ol' : 'ul');
               </p>
             )}
             {row.title && (
-              <h3 class="font-heading text-xl leading-snug font-semibold tracking-tight text-foreground sm:text-2xl">
+              <h3
+                class:list={[
+                  'font-heading font-semibold tracking-tight text-foreground',
+                  headingSizeClass('title'),
+                ]}
+              >
                 {row.title}
               </h3>
             )}

--- a/src/components/composites/FeatureCard.astro
+++ b/src/components/composites/FeatureCard.astro
@@ -3,13 +3,14 @@
  * FeatureCard - semantic feature card built on BaseCard
  *
  * Expressive tier card for highlights and feature grids.
+ * Prefer text titles over decorative emoji icons.
  */
 
 import BaseCard from '../primitives/BaseCard.astro';
+import { headingSizeClass } from '../../lib/typeScale';
 
 interface Props {
   variant?: 'accent' | 'primary' | 'success' | 'warning' | 'info' | 'error';
-  icon?: string;
   title?: string;
   titleLevel?: 2 | 3;
   description?: string;
@@ -20,7 +21,6 @@ interface Props {
 
 const {
   variant = 'accent',
-  icon,
   title,
   titleLevel = 3,
   description,
@@ -63,6 +63,8 @@ const classes = [
 ]
   .filter(Boolean)
   .join(' ');
+
+const TitleTag = titleLevel === 2 ? 'h2' : 'h3';
 ---
 
 <BaseCard
@@ -82,22 +84,25 @@ const classes = [
     )
   }
 
-  {icon && <div class="mb-3 text-5xl @sm:mb-4 @sm:text-6xl">{icon}</div>}
-
   {
-    title &&
-      (titleLevel === 2 ? (
-        <h2 class={`mb-2 text-xl font-bold @sm:mb-3 @sm:text-2xl ${variantTextColors[variant]}`}>
-          {title}
-        </h2>
-      ) : (
-        <h3 class={`mb-2 text-xl font-bold @sm:mb-3 @sm:text-2xl ${variantTextColors[variant]}`}>
-          {title}
-        </h3>
-      ))
+    title && (
+      <TitleTag
+        class:list={[
+          'mb-2 font-heading font-semibold @sm:mb-3',
+          headingSizeClass('title'),
+          variantTextColors[variant],
+        ]}
+      >
+        {title}
+      </TitleTag>
+    )
   }
 
-  {description && <p class="text-base leading-relaxed opacity-85 @sm:text-lg">{description}</p>}
+  {
+    description && (
+      <p class="text-base leading-relaxed text-muted-foreground @sm:text-lg">{description}</p>
+    )
+  }
 
   <slot />
 </BaseCard>

--- a/src/components/composites/hero.css
+++ b/src/components/composites/hero.css
@@ -1,5 +1,6 @@
 /**
- * Hero motion and gradient wash — colocated with home/page heroes.
+ * Hero motion and quiet surface wash — colocated with home/page heroes.
+ * Decorative blur orbs / radial washes live elsewhere are banned by design:lint.
  */
 
 @layer components {
@@ -9,49 +10,6 @@
       color-mix(in oklch, var(--color-surface) 88%, transparent),
       color-mix(in oklch, var(--color-background) 96%, transparent)
     );
-  }
-
-  .hero-gradient-animated {
-    @apply relative overflow-hidden;
-  }
-
-  .hero-gradient-animated::before {
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    pointer-events: none;
-    content: '';
-    background:
-      radial-gradient(
-        ellipse 70% 55% at 85% 40%,
-        color-mix(in oklch, var(--color-accent) 14%, transparent),
-        transparent 70%
-      ),
-      radial-gradient(
-        ellipse 50% 40% at 10% 80%,
-        color-mix(in oklch, var(--color-primary) 8%, transparent),
-        transparent 65%
-      );
-  }
-
-  .hero-with-atmosphere::after {
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    pointer-events: none;
-    content: '';
-    background-image: var(--hero-atmosphere-image);
-    background-position: 70% 30%;
-    background-size: cover;
-    background-repeat: no-repeat;
-    opacity: 0.14;
-    filter: blur(28px) saturate(0.85);
-    transform: scale(1.12);
-    mask-image: radial-gradient(ellipse 75% 70% at 70% 40%, black 20%, transparent 72%);
-  }
-
-  :root:not(.dark):not([data-theme='dark']) .hero-with-atmosphere::after {
-    opacity: 0.1;
   }
 
   .hero-entrance > * {
@@ -96,24 +54,5 @@
     position: relative;
     overflow: hidden;
     background-color: var(--color-surface-subtle);
-  }
-
-  .home-cta-band::before {
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    pointer-events: none;
-    content: '';
-    background:
-      radial-gradient(
-        ellipse 50% 60% at 50% 40%,
-        color-mix(in oklch, var(--color-accent) 14%, transparent),
-        transparent 70%
-      ),
-      radial-gradient(
-        ellipse 45% 50% at 50% 100%,
-        color-mix(in oklch, var(--color-primary) 8%, transparent),
-        transparent 65%
-      );
   }
 }

--- a/src/components/features/about/AboutEducationSkillsSection.astro
+++ b/src/components/features/about/AboutEducationSkillsSection.astro
@@ -4,6 +4,7 @@
  */
 import Section from '../../primitives/Section.astro';
 import SectionHeader from '../../composites/SectionHeader.astro';
+import { headingSizeClass } from '../../../lib/typeScale';
 
 export interface AboutEducationContent {
   kicker: string;
@@ -41,7 +42,12 @@ const { content } = Astro.props;
       <p class="text-xs font-semibold tracking-smallcaps text-subtle-foreground uppercase">
         Education
       </p>
-      <h3 class="font-heading text-2xl leading-snug font-semibold tracking-tight text-foreground">
+      <h3
+        class:list={[
+          'font-heading font-semibold tracking-tight text-foreground',
+          headingSizeClass('title'),
+        ]}
+      >
         {content.degree}
       </h3>
       <p class="text-base font-semibold text-accent-emphasis">{content.institution}</p>

--- a/src/components/features/blog/BlogIndexContentSection.astro
+++ b/src/components/features/blog/BlogIndexContentSection.astro
@@ -7,6 +7,7 @@ import Button from '../../primitives/Button.astro';
 import Badge from '../../primitives/Badge.astro';
 import BaseCard from '../../primitives/BaseCard.astro';
 import { BlogPostRow } from './index';
+import { headingSizeClass } from '../../../lib/typeScale';
 
 interface Props {
   posts: CollectionEntry<'blog'>[];
@@ -59,7 +60,7 @@ const { posts } = Astro.props as Props;
           <span class="section-kicker w-fit">Archive</span>
           <h2
             id="blog-posts-heading"
-            class="font-heading text-2xl font-semibold text-foreground sm:text-3xl md:text-4xl"
+            class:list={['font-heading font-semibold text-foreground', headingSizeClass('section')]}
           >
             Latest insights
           </h2>
@@ -78,7 +79,12 @@ const { posts } = Astro.props as Props;
           ))
         ) : (
           <BaseCard variant="elevated" hover="none" rounded="3xl" padding="lg" class="text-center">
-            <h2 class="mb-4 font-heading text-2xl font-semibold text-foreground sm:text-3xl">
+            <h2
+              class:list={[
+                'mb-4 font-heading font-semibold text-foreground',
+                headingSizeClass('title'),
+              ]}
+            >
               Articles are on the way
             </h2>
             <p class="text-sm leading-relaxed text-muted-foreground">

--- a/src/components/features/blog/BlogPostRow.astro
+++ b/src/components/features/blog/BlogPostRow.astro
@@ -10,6 +10,7 @@ import GradientOverlay from '../../primitives/GradientOverlay.astro';
 import ArrowRightIcon from '../../primitives/icons/ArrowRightIcon.astro';
 import { formatDateISO, formatDateShort } from '../../../utils/index.js';
 import { cn } from '../../../utils/cn';
+import { headingSizeClass } from '../../../lib/typeScale';
 
 const { post, align = 'left' } = Astro.props as BlogPostRowProps;
 const { id: slug, data } = post;
@@ -70,7 +71,10 @@ const { id: slug, data } = post;
         </Flex>
 
         <h2
-          class="font-heading text-2xl leading-tight font-semibold text-pretty text-foreground transition-colors duration-moderate group-hover:text-accent-emphasis sm:text-3xl lg:text-4xl"
+          class:list={[
+            'font-heading font-semibold text-pretty text-foreground transition-colors duration-moderate group-hover:text-accent-emphasis',
+            headingSizeClass('section'),
+          ]}
         >
           <a
             href={`/blog/${slug}/`}

--- a/src/components/features/home/HomeHeroSection.astro
+++ b/src/components/features/home/HomeHeroSection.astro
@@ -22,21 +22,11 @@ const { author, description, content } = Astro.props as Props;
    * Mobile — stacked, centered. Desktop — coin beside copy, group centered as a unit.
    */
 }
-<PageHero
-  id="about-me"
-  class="hero-gradient-animated hero-with-atmosphere"
-  includeBlurOrbs={false}
-  style={`--hero-atmosphere-image: url('${content.portrait.frontSrc}')`}
->
+<PageHero id="about-me" includeBlurOrbs={false}>
   <div
     class="hero-entrance relative z-10 mx-auto flex w-full max-w-5xl flex-col items-center gap-7 text-center lg:flex-row lg:items-center lg:justify-center lg:gap-12 lg:text-left xl:gap-14"
   >
     <div class="relative shrink-0 pb-4 lg:pb-5">
-      <div
-        class="pointer-events-none absolute -inset-[12%] rounded-full bg-accent-subtle blur-3xl"
-        aria-hidden="true"
-      >
-      </div>
       <div
         class="relative rounded-full ring-1 ring-accent/30 ring-offset-2 ring-offset-background sm:ring-offset-4"
       >

--- a/src/components/features/projects/ProjectDetailSection.astro
+++ b/src/components/features/projects/ProjectDetailSection.astro
@@ -3,6 +3,8 @@
  * Project detail section — editorial chrome matching home / case insights.
  * No elevated cards; kicker + heading + optional lead.
  */
+import { headingSizeClass } from '../../../lib/typeScale';
+
 export interface Props {
   title: string;
   eyebrow?: string;
@@ -19,7 +21,10 @@ const { title, eyebrow, id, description, class: className = '' } = Astro.props;
     {eyebrow && <span class="section-kicker">{eyebrow}</span>}
     <h2
       id={id}
-      class="font-heading text-2xl leading-snug font-semibold tracking-tight text-foreground sm:text-3xl md:text-4xl"
+      class:list={[
+        'font-heading font-semibold tracking-tight text-foreground',
+        headingSizeClass('section'),
+      ]}
     >
       {title}
     </h2>

--- a/src/components/features/projects/ProjectHero.astro
+++ b/src/components/features/projects/ProjectHero.astro
@@ -7,6 +7,7 @@ import Button from '../../primitives/Button.astro';
 import DotMetaList from '../../composites/DotMetaList.astro';
 import ArrowLeftIcon from '../../primitives/icons/ArrowLeftIcon.astro';
 import ExternalLinkIcon from '../../primitives/icons/ExternalLinkIcon.astro';
+import { headingSizeClass } from '../../../lib/typeScale';
 
 export interface Props {
   title: string;
@@ -29,12 +30,6 @@ const dateISO = date.toISOString();
 ---
 
 <section class="relative isolate overflow-hidden border-b border-border/40 py-14 sm:py-16 md:py-20">
-  <div
-    class="pointer-events-none absolute top-0 right-0 size-96 rounded-full bg-accent-subtle blur-3xl"
-    aria-hidden="true"
-  >
-  </div>
-
   <Container size="xl" class="relative z-10">
     <div class="grid items-center gap-8 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:gap-12">
       <div class="flex flex-col gap-5">
@@ -56,7 +51,10 @@ const dateISO = date.toISOString();
         <div class="space-y-2.5">
           <p class="section-kicker">Case study</p>
           <h1
-            class="font-heading text-4xl leading-[1.1] font-semibold tracking-tight text-pretty text-foreground sm:text-5xl lg:text-6xl"
+            class:list={[
+              'font-heading font-semibold tracking-tight text-pretty text-foreground',
+              headingSizeClass('hero'),
+            ]}
           >
             {title}
           </h1>

--- a/src/components/features/projects/ProjectTags.astro
+++ b/src/components/features/projects/ProjectTags.astro
@@ -3,6 +3,7 @@
  * Related stack labels — display only (no broken ?filter= links).
  */
 import DotMetaList from '../../composites/DotMetaList.astro';
+import { headingSizeClass } from '../../../lib/typeScale';
 
 export interface Props {
   tags: string[];
@@ -21,7 +22,10 @@ const normalizedTags = Array.isArray(tags)
       <div class="max-w-2xl space-y-2">
         <h2
           id="case-stack-heading"
-          class="font-heading text-xl leading-snug font-semibold tracking-tight text-foreground sm:text-2xl"
+          class:list={[
+            'font-heading font-semibold tracking-tight text-foreground',
+            headingSizeClass('title'),
+          ]}
         >
           Stack & focus
         </h2>

--- a/src/content/blog/ai-statistics-future-decision-making.mdx
+++ b/src/content/blog/ai-statistics-future-decision-making.mdx
@@ -9,8 +9,6 @@ featured: true
 ---
 
 <div className="relative my-12 overflow-hidden rounded-3xl border border-accent/20 bg-gradient-to-br from-accent/10 via-primary/5 to-accent/10 p-12 md:p-16">
-  <div className="absolute top-0 right-0 h-96 w-96 rounded-full bg-accent-subtle blur-3xl"></div>
-  <div className="absolute bottom-0 left-0 h-64 w-64 rounded-full bg-primary/10 blur-3xl"></div>
   <div className="relative text-center">
     <div className="mb-6 text-7xl">📊</div>
     <h2 className="mb-6 bg-gradient-to-r from-accent-emphasis to-primary-emphasis bg-clip-text text-4xl font-black text-transparent md:text-5xl">
@@ -153,7 +151,6 @@ featured: true
   <div className="grid md:grid-cols-2 gap-8">
     {/* RAG Card */}
     <div className="relative overflow-hidden bg-gradient-to-br from-accent/10 to-primary/10 rounded-2xl p-8 border-2 border-accent/40 shadow-lg">
-      <div className="absolute -top-10 -right-10 w-32 h-32 bg-accent/20 rounded-full blur-2xl"></div>
       <div className="relative">
         <div className="flex items-center gap-3 mb-6">
           <div className="text-5xl">📚</div>
@@ -179,7 +176,6 @@ featured: true
 
     {/* CAG Card */}
     <div className="relative overflow-hidden bg-gradient-to-br from-primary/10 to-accent/10 rounded-2xl p-8 border-2 border-primary/40 shadow-lg">
-      <div className="absolute -top-10 -right-10 w-32 h-32 bg-primary/20 rounded-full blur-2xl"></div>
       <div className="relative">
         <div className="flex items-center gap-3 mb-6">
           <div className="text-5xl">💾</div>
@@ -232,8 +228,6 @@ featured: true
 </div>
 
 <div className="relative overflow-hidden bg-gradient-to-br from-accent/10 via-primary/10 to-accent/10 rounded-3xl p-12 md:p-16 my-16 border-2 border-accent/40 shadow-lg">
-  <div className="absolute top-0 right-0 w-64 h-64 bg-accent-subtle rounded-full blur-3xl"></div>
-  <div className="absolute bottom-0 left-0 w-64 h-64 bg-primary/10 rounded-full blur-3xl"></div>
   
   <div className="relative text-center mb-10">
     <div className="inline-block bg-surface/90 backdrop-blur-sm rounded-2xl px-8 py-4 border-2 border-accent/30 shadow-lg mb-8">
@@ -270,8 +264,6 @@ featured: true
 ---
 
 <div className="relative my-20 overflow-hidden rounded-3xl bg-gradient-to-r from-accent-emphasis to-primary-emphasis p-12 shadow-lg md:p-16">
-  <div className="absolute -top-20 -right-20 h-64 w-64 rounded-full bg-on-dark/10 blur-3xl"></div>
-  <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-on-dark/10 blur-3xl"></div>
   <div className="relative mx-auto max-w-5xl text-center text-on-dark">
     <p className="mb-8 text-4xl leading-tight font-black drop-shadow-lg md:text-6xl">
       The next frontier isn't just <span className="text-warning-light">smarter models</span>
@@ -291,7 +283,6 @@ featured: true
 </div>
 
 <div className="relative overflow-hidden bg-gradient-to-br from-surface-subtle to-surface rounded-3xl p-12 md:p-16 my-16 border-2 border-border/50 shadow-lg">
-  <div className="absolute top-0 right-0 w-64 h-64 bg-accent/5 rounded-full blur-3xl"></div>
   <div className="relative text-center">
     <div className="inline-block bg-accent-subtle px-6 py-3 rounded-full border border-accent/30 mb-6">
       <span className="text-sm font-bold uppercase tracking-wider text-accent-emphasis">About This Research</span>

--- a/src/content/blog/building-my-own-local-llm-stack.mdx
+++ b/src/content/blog/building-my-own-local-llm-stack.mdx
@@ -9,8 +9,6 @@ featured: true
 ---
 
 <div className="relative my-12 overflow-hidden rounded-3xl border border-accent/20 bg-gradient-to-br from-accent/10 via-primary/5 to-accent/10 p-12 md:p-16">
-  <div className="absolute top-0 right-0 h-96 w-96 rounded-full bg-accent-subtle blur-3xl"></div>
-  <div className="absolute bottom-0 left-0 h-64 w-64 rounded-full bg-primary/10 blur-3xl"></div>
   <div className="relative z-10">
     <div className="mb-8 flex items-center gap-4">
       <div className="text-7xl">🔐</div>
@@ -87,11 +85,9 @@ featured: true
 </div>
 
 <div className="relative my-16">
-  <div className="absolute inset-0 bg-gradient-to-r from-accent/5 via-primary/5 to-accent/5 blur-3xl"></div>
   <div className="relative grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
     <div className="group relative overflow-hidden rounded-2xl border border-success/30 bg-success-subtle p-6 shadow-sm">
-      <div className="absolute top-0 right-0 w-32 h-32 bg-success/10 rounded-full blur-2xl group-hover:bg-success/20 transition-all duration-300"></div>
       <div className="relative">
         <div className="text-6xl mb-4">💻</div>
         <h3 className="text-2xl font-bold mb-3 text-success-emphasis">Mac Mini (M1)</h3>
@@ -100,7 +96,6 @@ featured: true
     </div>
 
     <div className="group relative overflow-hidden rounded-2xl border border-warning/30 bg-warning-subtle p-6 shadow-sm">
-      <div className="absolute top-0 right-0 w-32 h-32 bg-warning/10 rounded-full blur-2xl group-hover:bg-warning/20 transition-all duration-300"></div>
       <div className="relative">
         <div className="text-6xl mb-4">🤖</div>
         <h3 className="text-2xl font-bold mb-3 text-warning-emphasis">Ollama</h3>
@@ -109,7 +104,6 @@ featured: true
     </div>
 
     <div className="group relative overflow-hidden rounded-2xl border border-accent/30 bg-accent-subtle p-6 shadow-sm">
-      <div className="absolute top-0 right-0 w-32 h-32 bg-accent-subtle rounded-full blur-2xl group-hover:bg-accent/20 transition-all duration-300"></div>
       <div className="relative">
         <div className="text-6xl mb-4">🖥️</div>
         <h3 className="text-2xl font-bold mb-3 text-accent-emphasis">Open WebUI</h3>
@@ -118,7 +112,6 @@ featured: true
     </div>
 
     <div className="group relative overflow-hidden rounded-2xl border border-accent/30 bg-accent-subtle p-6 shadow-sm">
-      <div className="absolute top-0 right-0 w-32 h-32 bg-accent-subtle rounded-full blur-2xl group-hover:bg-accent/20 transition-all duration-300"></div>
       <div className="relative">
         <div className="text-6xl mb-4">🔒</div>
         <h3 className="text-2xl font-bold mb-3 text-accent-emphasis">Cloudflare Tunnel</h3>
@@ -127,7 +120,6 @@ featured: true
     </div>
 
     <div className="group relative overflow-hidden rounded-2xl border border-info/30 bg-info/10 p-6 shadow-sm">
-      <div className="absolute top-0 right-0 w-32 h-32 bg-info/10 rounded-full blur-2xl group-hover:bg-info/20 transition-all duration-300"></div>
       <div className="relative">
         <div className="text-6xl mb-4">⚡</div>
         <h3 className="text-2xl font-bold mb-3 text-info-emphasis">LaunchDaemons</h3>
@@ -136,7 +128,6 @@ featured: true
     </div>
 
     <div className="group relative overflow-hidden rounded-2xl border border-error/30 bg-error-subtle p-6 shadow-sm">
-      <div className="absolute top-0 right-0 w-32 h-32 bg-error/10 rounded-full blur-2xl group-hover:bg-error/20 transition-all duration-300"></div>
       <div className="relative">
         <div className="text-6xl mb-4">🛡️</div>
         <h3 className="text-2xl font-bold mb-3 text-error-emphasis">SSH Hardening</h3>
@@ -148,8 +139,6 @@ featured: true
 </div>
 
 <div className="relative my-16 overflow-hidden rounded-3xl border-2 border-accent/30 bg-gradient-to-br from-accent/5 via-primary/5 to-accent/5 p-10">
-  <div className="absolute -top-10 -right-10 h-40 w-40 rounded-full bg-accent-subtle blur-3xl"></div>
-  <div className="absolute -bottom-10 -left-10 h-40 w-40 rounded-full bg-primary/10 blur-3xl"></div>
   <div className="relative mx-auto max-w-4xl text-center">
     <p className="text-2xl leading-relaxed font-medium italic md:text-3xl">
       I wanted something that behaved like a{' '}
@@ -395,7 +384,6 @@ featured: true
 </div>
 
 <div className="blog-callout-warning relative overflow-hidden">
-  <div className="absolute top-0 right-0 h-64 w-64 rounded-full bg-warning/10 blur-3xl"></div>
   <div className="relative flex items-start gap-5">
     <div className="flex-shrink-0 text-6xl">⚠️</div>
     <div>
@@ -419,8 +407,6 @@ featured: true
 </div>
 
 <div className="relative my-20 overflow-hidden rounded-3xl bg-gradient-to-r from-accent-emphasis to-primary-emphasis p-12 shadow-lg md:p-16">
-  <div className="absolute -top-20 -right-20 h-64 w-64 rounded-full bg-on-dark/10 blur-3xl"></div>
-  <div className="absolute -bottom-20 -left-20 h-64 w-64 rounded-full bg-on-dark/10 blur-3xl"></div>
   <div className="relative text-center text-on-dark">
     <p className="mb-6 text-2xl leading-tight font-bold md:text-3xl">
       With a clean, browser-based interface on my laptop or phone, it's easy to use and completely
@@ -500,7 +486,6 @@ featured: true
 </div>
 
 <div className="relative my-16 overflow-hidden rounded-3xl border-2 border-error/40 bg-error-subtle p-10 shadow-lg">
-  <div className="absolute -top-10 -right-10 h-48 w-48 rounded-full bg-error/10 blur-3xl"></div>
   <div className="relative text-center">
     <div className="mb-4 text-7xl">💊</div>
     <p className="text-2xl font-bold text-error-emphasis md:text-3xl">And of course...</p>
@@ -517,8 +502,6 @@ featured: true
 </div>
 
 <div className="relative overflow-hidden bg-gradient-to-br from-accent/10 via-primary/10 to-accent/10 rounded-3xl p-12 md:p-16 my-16 border-2 border-accent/40 shadow-lg">
-  <div className="absolute top-0 right-0 w-96 h-96 bg-accent-subtle rounded-full blur-3xl"></div>
-  <div className="absolute bottom-0 left-0 w-96 h-96 bg-primary/10 rounded-full blur-3xl"></div>
   
   <div className="relative">
     <p className="text-xl md:text-2xl leading-relaxed mb-10 opacity-95">This project brought together multiple engineering disciplines:</p>
@@ -563,7 +546,6 @@ featured: true
 <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 my-16">
 
 <div className="group relative overflow-hidden rounded-3xl bg-gradient-to-br from-accent-emphasis to-primary-emphasis p-10 text-on-dark shadow-lg transition-all duration-500 hover:scale-[1.03] hover:shadow-lg">
-  <div className="absolute -top-10 -right-10 h-40 w-40 rounded-full bg-on-dark/10 blur-2xl transition-all duration-500 group-hover:bg-on-dark/20"></div>
   <div className="relative">
     <div className="mb-6 text-6xl">🧠</div>
     <strong className="mb-4 block text-3xl font-bold">Vector Memory</strong>
@@ -574,7 +556,6 @@ featured: true
 </div>
 
 <div className="group relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary to-accent p-10 text-on-dark shadow-lg transition-all duration-500 hover:scale-[1.03] hover:shadow-lg">
-  <div className="absolute -top-10 -right-10 h-40 w-40 rounded-full bg-on-dark/10 blur-2xl transition-all duration-500 group-hover:bg-on-dark/20"></div>
   <div className="relative">
     <div className="mb-6 text-6xl">🤖</div>
     <strong className="mb-4 block text-3xl font-bold">Agent Workflows</strong>
@@ -585,7 +566,6 @@ featured: true
 </div>
 
 <div className="group relative overflow-hidden rounded-3xl bg-gradient-to-br from-accent-emphasis to-primary-emphasis p-10 text-on-dark shadow-lg transition-all duration-500 hover:scale-[1.03] hover:shadow-lg">
-  <div className="absolute -top-10 -right-10 h-40 w-40 rounded-full bg-on-dark/10 blur-2xl transition-all duration-500 group-hover:bg-on-dark/20"></div>
   <div className="relative">
     <div className="mb-6 text-6xl">📦</div>
     <strong className="mb-4 block text-3xl font-bold">Template Package</strong>
@@ -596,7 +576,6 @@ featured: true
 </div>
 
 <div className="group relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary to-accent p-10 text-on-dark shadow-lg transition-all duration-500 hover:scale-[1.03] hover:shadow-lg">
-  <div className="absolute -top-10 -right-10 h-40 w-40 rounded-full bg-on-dark/10 blur-2xl transition-all duration-500 group-hover:bg-on-dark/20"></div>
   <div className="relative">
     <div className="mb-6 text-6xl">📱</div>
     <strong className="mb-4 block text-3xl font-bold">PWA Support</strong>
@@ -622,8 +601,6 @@ featured: true
 </div>
 
 <div className="relative my-20 overflow-hidden rounded-3xl bg-gradient-to-br from-accent-emphasis via-primary-emphasis to-accent-emphasis p-16 shadow-lg md:p-20">
-  <div className="absolute -top-32 -right-32 h-96 w-96 rounded-full bg-on-dark/10 blur-3xl"></div>
-  <div className="absolute -bottom-32 -left-32 h-96 w-96 rounded-full bg-on-dark/10 blur-3xl"></div>
 
   <div className="relative mx-auto max-w-5xl text-center text-on-dark">
     <p className="mb-8 text-4xl leading-tight font-black drop-shadow-lg md:text-6xl">

--- a/src/content/blog/ces-2026-ai-has-left-the-screen.mdx
+++ b/src/content/blog/ces-2026-ai-has-left-the-screen.mdx
@@ -18,8 +18,6 @@ import { Image } from 'astro:assets';
 import NvidiaPrize from '@/assets/images/carousel/Nvidia-prize-download.webp';
 
 <div className="relative overflow-hidden bg-gradient-to-br from-accent/10 via-primary/5 to-accent/10 rounded-3xl p-10 md:p-14 my-12 border border-accent/20">
-  <div className="absolute top-0 right-0 w-96 h-96 bg-accent-subtle rounded-full blur-3xl"></div>
-  <div className="absolute bottom-0 left-0 w-72 h-72 bg-primary/10 rounded-full blur-3xl"></div>
   <div className="relative">
     <div className="flex flex-col gap-6">
       <div className="inline-flex items-center gap-3 self-start rounded-full bg-surface/70 px-4 py-2 ring-1 ring-border/30 backdrop-blur">

--- a/src/content/blog/combating-legal-ai-hallucinations.mdx
+++ b/src/content/blog/combating-legal-ai-hallucinations.mdx
@@ -18,7 +18,6 @@ import ButtonGroup from '../../components/composites/ButtonGroup.astro';
 <FeatureCard
   titleLevel={2}
   variant="accent"
-  icon="⚖️"
   title="Ground legal AI in verified source material"
   class="my-12 text-center"
 >
@@ -39,7 +38,6 @@ AI-assisted research creates real leverage for faster case review, better synthe
 <FeatureCard
   titleLevel={2}
   variant="error"
-  icon="⚠️"
   title="The failure mode is confident inaccuracy"
   class="my-10"
 >
@@ -63,28 +61,24 @@ The operational requirement is straightforward:
   <FeatureCard
     titleLevel={2}
     variant="accent"
-    icon="🔗"
     title="Grounded citations"
     description="Responses include the CourtListener ID and source link for each cited document."
   />
   <FeatureCard
     titleLevel={2}
     variant="primary"
-    icon="📄"
     title="Verified documents"
     description="The server can return the opinion, docket, or transcript needed for direct review."
   />
   <FeatureCard
     titleLevel={2}
     variant="accent"
-    icon="🔍"
     title="Real-time search"
     description="Queries run through CourtListener so newly available decisions can be surfaced immediately."
   />
   <FeatureCard
     titleLevel={2}
     variant="primary"
-    icon="🛡️"
     title="Auditability"
     description="Requests and outputs can be logged so compliance and review teams have a durable record."
   />
@@ -147,21 +141,18 @@ Current expansion areas are focused on depth rather than novelty:
   <FeatureCard
     titleLevel={2}
     variant="warning"
-    icon="📦"
     title="Bulk export utilities"
     description="Support litigation knowledge-base workflows without manual handoffs."
   />
   <FeatureCard
     titleLevel={2}
     variant="accent"
-    icon="📊"
     title="Conflict analytics"
     description="Identify conflicting authorities across jurisdictions with better review support."
   />
   <FeatureCard
     titleLevel={2}
     variant="success"
-    icon="⚡"
     title="Performance hardening"
     description="Add caching and rate-control layers for larger research teams."
   />

--- a/src/data/componentDocs.ts
+++ b/src/data/componentDocs.ts
@@ -1083,7 +1083,7 @@ export const componentDocs: ComponentDoc[] = [
     name: 'FeatureCard',
     category: 'Composites',
     description:
-      'Semantic feature surface with token-backed color variants. Use for marketing/feature grids instead of page-specific card styles.',
+      'Semantic feature surface with token-backed color variants. Use for marketing/feature grids instead of page-specific card styles. Prefer text titles — no emoji icon prop.',
     filePath: 'src/components/composites/FeatureCard.astro',
     props: [
       {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -12,6 +12,7 @@ import {
   createBreadcrumbListSchema,
   defaultAuthor,
 } from '../../utils/structuredData';
+import { headingSizeClass } from '../../lib/typeScale';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }: CollectionEntry<'blog'>) => !data.draft);
@@ -91,7 +92,10 @@ const structuredData = [articleSchema, breadcrumbSchema];
           }
         </Flex>
         <h1
-          class="font-heading text-4xl leading-tight font-bold text-foreground sm:text-5xl md:text-6xl"
+          class:list={[
+            'font-heading font-semibold tracking-tight text-foreground',
+            headingSizeClass('hero'),
+          ]}
         >
           {post.data.title}
         </h1>


### PR DESCRIPTION
## Summary
- Remove leftover hero orbs/washes, FeatureCard emoji icons, and blog MDX blur decoration
- Migrate remaining feature/blog headings onto the shared `typeScale` ladder
- Extend `design:lint` to ban blur orbs, BadgePill imports, DIY elevated cards, and ad-hoc heading ladders

## Test plan
- [ ] Spot-check home hero (no coin halo / atmosphere wash) and a project case-study hero
- [ ] Spot-check blog index + a post with FeatureCards (legal AI post)
- [ ] `pnpm design:lint` and `pnpm typecheck` pass
- [ ] Confirm `/design/patterns` FeatureCard demo still renders without icons


Made with [Cursor](https://cursor.com)