### PR TITLE
fix(security): clear CodeQL alerts for main promotion

### DIFF
--- a/functions/index.ts
+++ b/functions/index.ts
@@ -3,6 +3,7 @@
  */
 import { initEdgeSentry } from '../sentry.edge.config.js';
 import type { Env } from './types';
+import { isBlakeOxfordHostname } from './shared/hostname';
 import { generateRequestId } from './shared/request-id';
 import type { RouteContext } from './shared/route-context';
 import { handleRobotsFavicon } from './routes/robots-favicon';
@@ -70,7 +71,7 @@ const WorkerApp = {
     try {
       const host = url.hostname;
       const isGetLike = request.method === 'GET' || request.method === 'HEAD';
-      const isProdDomain = host.endsWith('blakeoxford.com');
+      const isProdDomain = isBlakeOxfordHostname(host);
       if (isProdDomain && url.protocol === 'http:' && isGetLike) {
         url.protocol = 'https:';
         const r = Response.redirect(url.toString(), 308);

--- a/functions/routes/assets.ts
+++ b/functions/routes/assets.ts
@@ -409,7 +409,6 @@ export async function handleAssets({
     if (url.pathname.startsWith('/api/')) {
       const errorPayload = {
         error: 'Internal server error',
-        message: err.message || String(error),
         path: url.pathname,
         requestId: reqId,
       };

--- a/functions/routes/semantic-search.ts
+++ b/functions/routes/semantic-search.ts
@@ -129,16 +129,11 @@ export async function handleSemanticSearch({
       }
       queryEmbedding = embeddingData;
     } catch (error) {
-      return new Response(
-        JSON.stringify({
-          error: 'Failed to generate query embedding',
-          details: error instanceof Error ? error.message : String(error),
-        }),
-        {
-          status: 500,
-          headers: baseCorsHeaders,
-        }
-      );
+      console.error('Failed to generate query embedding', error);
+      return new Response(JSON.stringify({ error: 'Failed to generate query embedding' }), {
+        status: 500,
+        headers: baseCorsHeaders,
+      });
     }
 
     // Query Vectorize index
@@ -203,15 +198,10 @@ export async function handleSemanticSearch({
       }
     );
   } catch (error) {
-    return new Response(
-      JSON.stringify({
-        error: 'Semantic search failed',
-        details: error instanceof Error ? error.message : String(error),
-      }),
-      {
-        status: 500,
-        headers: baseCorsHeaders,
-      }
-    );
+    console.error('Semantic search failed', error);
+    return new Response(JSON.stringify({ error: 'Semantic search failed' }), {
+      status: 500,
+      headers: baseCorsHeaders,
+    });
   }
 }

--- a/functions/routes/theme.ts
+++ b/functions/routes/theme.ts
@@ -1,4 +1,5 @@
 import type { RouteContext } from '../shared/route-context';
+import { isBlakeOxfordHostname } from '../shared/hostname';
 
 export async function handleTheme({
   request,
@@ -57,7 +58,7 @@ export async function handleTheme({
 
   try {
     const maxAge = 60 * 60 * 24 * 365;
-    const isProd = url.hostname && url.hostname.endsWith('blakeoxford.com');
+    const isProd = Boolean(url.hostname && isBlakeOxfordHostname(url.hostname));
     const secureFlag = isProd ? '; Secure' : '';
     const cookie = `theme=${encodeURIComponent(theme)}; Path=/; Max-Age=${maxAge}; SameSite=Lax; HttpOnly${secureFlag}`;
     const headers = new Headers(corsHeaders);

--- a/functions/shared/hostname.ts
+++ b/functions/shared/hostname.ts
@@ -1,0 +1,4 @@
+/** True for apex and subdomains of blakeoxford.com (not spoofable suffix matches). */
+export function isBlakeOxfordHostname(hostname: string): boolean {
+  return hostname === 'blakeoxford.com' || hostname.endsWith('.blakeoxford.com');
+}

--- a/src/lib/ai-search-types.ts
+++ b/src/lib/ai-search-types.ts
@@ -71,15 +71,24 @@ export function getOrCreateAiSessionId(): string {
   try {
     const existing = window.localStorage.getItem(SESSION_STORAGE_KEY);
     if (existing && existing.length >= 8) return existing;
-    const created =
-      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-        ? crypto.randomUUID()
-        : `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+    const created = createAiSessionId();
     window.localStorage.setItem(SESSION_STORAGE_KEY, created);
     return created;
   } catch {
     return `sess_${Date.now().toString(36)}`;
   }
+}
+
+function createAiSessionId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(8);
+    crypto.getRandomValues(bytes);
+    return `sess_${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`;
+  }
+  return `sess_${Date.now().toString(36)}`;
 }
 
 export function readAISearchMeta(response: Response): AISearchMeta {


### PR DESCRIPTION
## Summary
- Fixes the 6 CodeQL alerts blocking [#410](https://github.com/blakeox/blakeoxford.com/pull/410) (`testing` → `main`).
- Hostname checks use apex/`*.blakeoxford.com`, API errors omit exception details, Ask session IDs use Web Crypto.

## Test plan
- [ ] Fast CI / CodeQL on this PR
- [ ] Merge into `testing`, confirm [#410](https://github.com/blakeox/blakeoxford.com/pull/410) goes CLEAN


Made with [Cursor](https://cursor.com)