### PR TITLE
fix(ci): allow main back-merges in branch flow guard

### DIFF
--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -37,6 +37,7 @@ jobs:
             const isCursorAgent = /^cursor\//.test(headLower);
             const isDev = head === 'development';
             const isTesting = head === 'testing';
+            const isMain = head === 'main';
 
             let allowed = false;
             let rule = '';
@@ -46,9 +47,10 @@ jobs:
             else if (isDev && toTesting) { allowed = true; rule = 'development -> testing'; }
             else if (isTesting && toMain) { allowed = true; rule = 'testing -> main'; }
             else if (isHotfix && toMain) { allowed = true; rule = 'hotfix/* -> main'; }
+            else if (isMain && (toDev || toTesting)) { allowed = true; rule = 'main -> development/testing (back-merge)'; }
 
             if (!allowed) {
-              core.setFailed(`Invalid branch flow: '${head}' -> '${base}'.\nAllowed flows:\n- feature/*, sprint/*, or cursor/* -> development\n- development -> testing\n- testing -> main\n- hotfix/* -> main (then back-merge to development/testing)\n`);
+              core.setFailed(`Invalid branch flow: '${head}' -> '${base}'.\nAllowed flows:\n- feature/*, sprint/*, or cursor/* -> development\n- development -> testing\n- testing -> main\n- hotfix/* -> main\n- main -> development or testing (back-merge after ship)\n`);
             } else {
               core.info(`Branch flow OK (${rule}): '${head}' -> '${base}'.`);
             }


### PR DESCRIPTION
## Summary
- Allow `main` → `development` and `main` → `testing` in Branch Flow Guard so post-ship back-merge PRs match CONTRIBUTING.
- Unblocks the pattern used by [#412](https://github.com/blakeox/blakeoxford.com/pull/412) / [#413](https://github.com/blakeox/blakeoxford.com/pull/413).

## Test plan
- [ ] Branch Flow Guard passes on this hotfix → main PR
- [ ] Future main → development/testing PRs no longer fail Enforce Branch Flow


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated branch flow validation to allow approved back-merges from `main` into `development` or `testing`.
  * Improved validation error messages to reflect the supported branch flows and hotfix rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->