### PR TITLE
chore: back-merge main → testing (branch flow hotfix)

### DIFF
--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -37,6 +37,7 @@ jobs:
             const isCursorAgent = /^cursor\//.test(headLower);
             const isDev = head === 'development';
             const isTesting = head === 'testing';
+            const isMain = head === 'main';
 
             let allowed = false;
             let rule = '';
@@ -46,9 +47,10 @@ jobs:
             else if (isDev && toTesting) { allowed = true; rule = 'development -> testing'; }
             else if (isTesting && toMain) { allowed = true; rule = 'testing -> main'; }
             else if (isHotfix && toMain) { allowed = true; rule = 'hotfix/* -> main'; }
+            else if (isMain && (toDev || toTesting)) { allowed = true; rule = 'main -> development/testing (back-merge)'; }
 
             if (!allowed) {
-              core.setFailed(`Invalid branch flow: '${head}' -> '${base}'.\nAllowed flows:\n- feature/*, sprint/*, or cursor/* -> development\n- development -> testing\n- testing -> main\n- hotfix/* -> main (then back-merge to development/testing)\n`);
+              core.setFailed(`Invalid branch flow: '${head}' -> '${base}'.\nAllowed flows:\n- feature/*, sprint/*, or cursor/* -> development\n- development -> testing\n- testing -> main\n- hotfix/* -> main\n- main -> development or testing (back-merge after ship)\n`);
             } else {
               core.info(`Branch flow OK (${rule}): '${head}' -> '${base}'.`);
             }

--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -47,7 +47,7 @@ jobs:
             else if (isDev && toTesting) { allowed = true; rule = 'development -> testing'; }
             else if (isTesting && toMain) { allowed = true; rule = 'testing -> main'; }
             else if (isHotfix && toMain) { allowed = true; rule = 'hotfix/* -> main'; }
-            else if (isMain && (toDev || toTesting)) { allowed = true; rule = 'main -> development/testing (back-merge)'; }
+            else if (isMain && (toDev || toTesting) && pr.head.repo.fork === false) { allowed = true; rule = 'main -> development/testing (back-merge)'; }
 
             if (!allowed) {
               core.setFailed(`Invalid branch flow: '${head}' -> '${base}'.\nAllowed flows:\n- feature/*, sprint/*, or cursor/* -> development\n- development -> testing\n- testing -> main\n- hotfix/* -> main\n- main -> development or testing (back-merge after ship)\n`);


### PR DESCRIPTION
## Summary
- Back-merge main into testing after hotfix #414 (allow main back-merges in branch flow guard).

## Test plan
- [ ] Branch Flow Guard passes for main → testing
- [ ] Required checks green


Made with [Cursor](https://cursor.com)