### PR TITLE
fix(ops): make edge monitor runner-safe

### DIFF
--- a/docs/operations/cloudflare-monitoring.md
+++ b/docs/operations/cloudflare-monitoring.md
@@ -47,13 +47,15 @@ protection` rule is active.
 ## Failure handling
 
 - **Monitor failure:** inspect the failed step and run the same script locally
-  with `EDGE_BASE_URL=https://blakeoxford.com`. Do not disable the monitor to
-  clear a red status.
+  with `EDGE_BASE_URL=https://blakeoxford.com`. The monitor identifies its
+  requests, retries transient edge denials, and prints only safe response
+  metadata when the failure persists. Do not disable the monitor to clear a
+  red status.
 - **Worker exception burst:** use Workers Logs/Traces and Sentry, then roll back
   the Worker to the last known-good deployment if customer impact is active.
-- **False-positive rate limiting:** temporarily disable the `API burst
-  protection` rule, retain the application-level limits, and restore the rule
-  after adjusting its threshold.
+- **False-positive rate limiting:** temporarily disable the `API burst protection`
+  rule, retain the application-level limits, and restore it after adjusting its
+  threshold.
 - **Secret failure:** disable the affected feature or route, rotate the secret,
   redeploy through the normal branch flow, and retest the route.
 

--- a/scripts/monitor/cloudflare-edge-smoke.sh
+++ b/scripts/monitor/cloudflare-edge-smoke.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 BASE_URL="${EDGE_BASE_URL:-https://blakeoxford.com}"
 TIMEOUT_SECONDS="${EDGE_TIMEOUT_SECONDS:-20}"
+RETRY_ATTEMPTS="${EDGE_RETRY_ATTEMPTS:-3}"
+USER_AGENT="${EDGE_USER_AGENT:-blakeoxford-edge-monitor/1.0 (+https://blakeoxford.com/)}"
 
 if [[ ! "$BASE_URL" =~ ^https://[^/]+$ ]]; then
   echo "EDGE_BASE_URL must be an HTTPS origin without a trailing path" >&2
@@ -20,10 +22,16 @@ request_status() {
 
   local actual
   actual="$(curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
-    --output /dev/null --write-out '%{http_code}' "$@")"
+    --retry "$RETRY_ATTEMPTS" --retry-all-errors --retry-delay 2 \
+    --user-agent "$USER_AGENT" --output /dev/null --write-out '%{http_code}' "$@")"
 
   if [[ "$actual" != "$expected" ]]; then
     echo "FAIL $label: expected HTTP $expected, received HTTP $actual" >&2
+    echo "Response metadata:" >&2
+    curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
+      --retry 1 --retry-delay 1 --user-agent "$USER_AGENT" \
+      --dump-header - --output /dev/null "$@" \
+      | awk -F': ' 'tolower($1) ~ /^(cf-ray|cf-cache-status|content-type|location|retry-after|server|x-request-id)$/ { print }' >&2 || true
     return 1
   fi
 
@@ -32,7 +40,8 @@ request_status() {
 
 request_headers() {
   curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
-    --dump-header - --output /dev/null "$BASE_URL/"
+    --retry "$RETRY_ATTEMPTS" --retry-all-errors --retry-delay 2 \
+    --user-agent "$USER_AGENT" --dump-header - --output /dev/null "$BASE_URL/"
 }
 
 request_status "homepage" 200 "$BASE_URL/"


### PR DESCRIPTION
## What changed
- identify edge monitor requests with an explicit user agent
- retry transient edge denials before failing
- print only safe Cloudflare response metadata for persistent failures
- document the failure-handling behavior

## Why
The GitHub-hosted monitor received repeatable HTTP 403 responses while the same production contract passed from local probes. This keeps the monitor useful without weakening the site WAF or adding a runner allowlist.

## Testing
- bash -n
- shellcheck
- live pnpm monitor:edge
- actionlint
- git diff --check

## Impact
No production Worker code or Cloudflare rules changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ops-only smoke script and runbook changes; no production Worker or Cloudflare rule changes.
> 
> **Overview**
> **Hardens the production edge smoke script** so GitHub Actions runs are less likely to fail on transient Cloudflare/WAF denials without changing Worker code or WAF allowlists.
> 
> `cloudflare-edge-smoke.sh` now sends a fixed **`EDGE_USER_AGENT`** (default `blakeoxford-edge-monitor/1.0`), applies **`EDGE_RETRY_ATTEMPTS`** (default 3) with `--retry-all-errors` on status and header probes, and on a status mismatch dumps **only allowlisted response headers** (`cf-ray`, `cf-cache-status`, `content-type`, etc.) for debugging.
> 
> **`docs/operations/cloudflare-monitoring.md`** updates the monitor-failure and rate-limit bullets to match (retries, safe metadata, minor wording on `API burst protection`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9788408c5272da1fb9893acd35058bd24f2c68ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->