### PR TITLE
chore(release): promote edge monitor hardening

### DIFF
--- a/docs/operations/cloudflare-monitoring.md
+++ b/docs/operations/cloudflare-monitoring.md
@@ -47,13 +47,15 @@ protection` rule is active.
 ## Failure handling
 
 - **Monitor failure:** inspect the failed step and run the same script locally
-  with `EDGE_BASE_URL=https://blakeoxford.com`. Do not disable the monitor to
-  clear a red status.
+  with `EDGE_BASE_URL=https://blakeoxford.com`. The monitor identifies its
+  requests, retries transient edge denials, and prints only safe response
+  metadata when the failure persists. Do not disable the monitor to clear a
+  red status.
 - **Worker exception burst:** use Workers Logs/Traces and Sentry, then roll back
   the Worker to the last known-good deployment if customer impact is active.
-- **False-positive rate limiting:** temporarily disable the `API burst
-  protection` rule, retain the application-level limits, and restore the rule
-  after adjusting its threshold.
+- **False-positive rate limiting:** temporarily disable the `API burst protection`
+  rule, retain the application-level limits, and restore it after adjusting its
+  threshold.
 - **Secret failure:** disable the affected feature or route, rotate the secret,
   redeploy through the normal branch flow, and retest the route.
 

--- a/scripts/monitor/cloudflare-edge-smoke.sh
+++ b/scripts/monitor/cloudflare-edge-smoke.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 BASE_URL="${EDGE_BASE_URL:-https://blakeoxford.com}"
 TIMEOUT_SECONDS="${EDGE_TIMEOUT_SECONDS:-20}"
+RETRY_ATTEMPTS="${EDGE_RETRY_ATTEMPTS:-3}"
+USER_AGENT="${EDGE_USER_AGENT:-blakeoxford-edge-monitor/1.0 (+https://blakeoxford.com/)}"
 
 if [[ ! "$BASE_URL" =~ ^https://[^/]+$ ]]; then
   echo "EDGE_BASE_URL must be an HTTPS origin without a trailing path" >&2
@@ -20,10 +22,16 @@ request_status() {
 
   local actual
   actual="$(curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
-    --output /dev/null --write-out '%{http_code}' "$@")"
+    --retry "$RETRY_ATTEMPTS" --retry-all-errors --retry-delay 2 \
+    --user-agent "$USER_AGENT" --output /dev/null --write-out '%{http_code}' "$@")"
 
   if [[ "$actual" != "$expected" ]]; then
     echo "FAIL $label: expected HTTP $expected, received HTTP $actual" >&2
+    echo "Response metadata:" >&2
+    curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
+      --retry 1 --retry-delay 1 --user-agent "$USER_AGENT" \
+      --dump-header - --output /dev/null "$@" \
+      | awk -F': ' 'tolower($1) ~ /^(cf-ray|cf-cache-status|content-type|location|retry-after|server|x-request-id)$/ { print }' >&2 || true
     return 1
   fi
 
@@ -32,7 +40,8 @@ request_status() {
 
 request_headers() {
   curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
-    --dump-header - --output /dev/null "$BASE_URL/"
+    --retry "$RETRY_ATTEMPTS" --retry-all-errors --retry-delay 2 \
+    --user-agent "$USER_AGENT" --dump-header - --output /dev/null "$BASE_URL/"
 }
 
 request_status "homepage" 200 "$BASE_URL/"


### PR DESCRIPTION
## What changed
Promote the runner-safe Cloudflare edge monitor fix from development to testing.

## Why
The scheduled monitor was receiving HTTP 403 from GitHub-hosted runners while the public site remained healthy from other networks. The fix adds an explicit monitor identity, bounded retries, and safe failure metadata without changing production WAF rules.

## Validation
- development Fast CI passed
- security and dependency checks passed
- Workers build passed
- essential E2E passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational monitoring and documentation only; no changes to Worker, WAF rules, or application auth/data paths.
> 
> **Overview**
> **Hardens the scheduled Cloudflare edge smoke script** so GitHub-hosted runners are less likely to fail with transient HTTP 403s while the public site stays healthy.
> 
> `cloudflare-edge-smoke.sh` now sends a dedicated **User-Agent** (`blakeoxford-edge-monitor/1.0`), applies **bounded curl retries** (`EDGE_RETRY_ATTEMPTS`, default 3) on all checks, and on assertion failure prints **safe response metadata** (filtered headers such as `cf-ray`, `cf-cache-status`, `server`) instead of only the status code.
> 
> The **Cloudflare monitoring runbook** documents this monitor behavior under failure handling and lightly reformats the false-positive rate-limit bullet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc44929c8cae8c2b1b8292a568175039b81377e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->