### PR TITLE
chore(release): promote runner-safe edge monitoring

### DIFF
--- a/docs/operations/cloudflare-monitoring.md
+++ b/docs/operations/cloudflare-monitoring.md
@@ -47,13 +47,15 @@ protection` rule is active.
 ## Failure handling
 
 - **Monitor failure:** inspect the failed step and run the same script locally
-  with `EDGE_BASE_URL=https://blakeoxford.com`. Do not disable the monitor to
-  clear a red status.
+  with `EDGE_BASE_URL=https://blakeoxford.com`. The monitor identifies its
+  requests, retries transient edge denials, and prints only safe response
+  metadata when the failure persists. Do not disable the monitor to clear a
+  red status.
 - **Worker exception burst:** use Workers Logs/Traces and Sentry, then roll back
   the Worker to the last known-good deployment if customer impact is active.
-- **False-positive rate limiting:** temporarily disable the `API burst
-  protection` rule, retain the application-level limits, and restore the rule
-  after adjusting its threshold.
+- **False-positive rate limiting:** temporarily disable the `API burst protection`
+  rule, retain the application-level limits, and restore it after adjusting its
+  threshold.
 - **Secret failure:** disable the affected feature or route, rotate the secret,
   redeploy through the normal branch flow, and retest the route.
 

--- a/scripts/monitor/cloudflare-edge-smoke.sh
+++ b/scripts/monitor/cloudflare-edge-smoke.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 BASE_URL="${EDGE_BASE_URL:-https://blakeoxford.com}"
 TIMEOUT_SECONDS="${EDGE_TIMEOUT_SECONDS:-20}"
+RETRY_ATTEMPTS="${EDGE_RETRY_ATTEMPTS:-3}"
+USER_AGENT="${EDGE_USER_AGENT:-blakeoxford-edge-monitor/1.0 (+https://blakeoxford.com/)}"
 
 if [[ ! "$BASE_URL" =~ ^https://[^/]+$ ]]; then
   echo "EDGE_BASE_URL must be an HTTPS origin without a trailing path" >&2
@@ -20,10 +22,16 @@ request_status() {
 
   local actual
   actual="$(curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
-    --output /dev/null --write-out '%{http_code}' "$@")"
+    --retry "$RETRY_ATTEMPTS" --retry-all-errors --retry-delay 2 \
+    --user-agent "$USER_AGENT" --output /dev/null --write-out '%{http_code}' "$@")"
 
   if [[ "$actual" != "$expected" ]]; then
     echo "FAIL $label: expected HTTP $expected, received HTTP $actual" >&2
+    echo "Response metadata:" >&2
+    curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
+      --retry 1 --retry-delay 1 --user-agent "$USER_AGENT" \
+      --dump-header - --output /dev/null "$@" \
+      | awk -F': ' 'tolower($1) ~ /^(cf-ray|cf-cache-status|content-type|location|retry-after|server|x-request-id)$/ { print }' >&2 || true
     return 1
   fi
 
@@ -32,7 +40,8 @@ request_status() {
 
 request_headers() {
   curl --silent --show-error --location --max-time "$TIMEOUT_SECONDS" \
-    --dump-header - --output /dev/null "$BASE_URL/"
+    --retry "$RETRY_ATTEMPTS" --retry-all-errors --retry-delay 2 \
+    --user-agent "$USER_AGENT" --dump-header - --output /dev/null "$BASE_URL/"
 }
 
 request_status "homepage" 200 "$BASE_URL/"


### PR DESCRIPTION
## What changed
Promote the runner-safe Cloudflare edge monitoring fix through testing to main.

## Why
GitHub-hosted monitoring was receiving repeatable HTTP 403 responses while production passed from local probes. The monitor now identifies its traffic, retries transient denials, and emits only safe response metadata without changing WAF rules.

## Validation
- development promotion checks passed
- testing branch contains the same merge commit
- Workers build and security/dependency checks are running for this promotion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the monitoring shell script and operations documentation; production traffic and application code are unaffected.
> 
> **Overview**
> **Hardens the production edge smoke script** so GitHub Actions probes are less likely to fail on transient 403s from the edge.
> 
> All `curl` calls in `cloudflare-edge-smoke.sh` now send a dedicated **`blakeoxford-edge-monitor/1.0`** user agent and **retry** transient errors (configurable via `EDGE_RETRY_ATTEMPTS`, default 3). When a check still fails, a follow-up request prints **only allowlisted response headers** (`cf-ray`, `cf-cache-status`, `content-type`, etc.) to stderr—no secrets or bodies.
> 
> The **Cloudflare monitoring runbook** is updated to describe this behavior on monitor failure and includes a small formatting fix for the API burst protection bullet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ea0fcf64297cb58f757295a81d9f8f131f9b7f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry attempts and custom user-agent settings for edge smoke tests.
  * Improved failure diagnostics with selected safe response headers.

* **Documentation**
  * Documented retry handling for transient edge denials and safe metadata reporting for persistent failures.
  * Clarified how to restore API burst protection after rate-limit adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->