### PR TITLE
fix(deps): remove duplicate lockfile entries

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4125,10 +4125,6 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
-    hasBin: true
-
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -11214,10 +11210,6 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.3.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.1:
     dependencies:


### PR DESCRIPTION
## What changed
- Remove duplicate `js-yaml@4.3.1` entries from the packages and snapshots sections.

## Why
- `pnpm install --frozen-lockfile` failed on `main` with `ERR_PNPM_BROKEN_LOCKFILE`.
- The malformed entries were introduced by the merged Astro Dependabot lockfile update.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run typecheck`
- `pnpm run build`

## Impact
- Lockfile-only correction; no runtime dependency versions changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only deduplication with no application code or version bumps; minimal operational risk beyond restoring CI install reliability.
> 
> **Overview**
> Repairs **`pnpm-lock.yaml`** by deleting duplicate **`js-yaml@4.3.1`** blocks in both the package resolution and snapshot sections, leaving a single canonical entry for each.
> 
> This is a lockfile hygiene fix only—resolved versions and dependency trees are unchanged. It restores **`pnpm install --frozen-lockfile`** after **`ERR_PNPM_BROKEN_LOCKFILE`** caused by malformed entries from a prior Astro Dependabot merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e28824cd96010decadc60f148f22cd75e7a1655. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->