### PR TITLE
fix(deps): remove duplicate lockfile entries

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4125,10 +4125,6 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
-    hasBin: true
-
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -11214,10 +11210,6 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.3.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.1:
     dependencies:


### PR DESCRIPTION
## What changed
- Remove duplicate `js-yaml@4.3.1` entries from the packages and snapshots sections.

## Why
- `pnpm install --frozen-lockfile` failed on `main` with `ERR_PNPM_BROKEN_LOCKFILE`.
- The malformed entries were introduced by the merged Astro Dependabot lockfile update.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run typecheck`
- `pnpm run build`

## Impact
- Lockfile-only correction; no runtime dependency versions changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only deduplication with no version bumps; lowest risk for CI and installs.
> 
> **Overview**
> **Fixes a broken lockfile** by deleting duplicate `js-yaml@4.3.1` entries in both the packages and snapshots sections of `pnpm-lock.yaml`. Each section had the same resolution/dependency block listed twice after a merged Dependabot Astro update, which triggered `ERR_PNPM_BROKEN_LOCKFILE` under `pnpm install --frozen-lockfile`.
> 
> No dependency versions or runtime behavior change—only the malformed duplicate lines are removed so the lockfile matches pnpm’s expected shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e28824cd96010decadc60f148f22cd75e7a1655. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->