### PR TITLE
fix(cloudflare): align required AI search secret

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -63,9 +63,9 @@ script_name = "blakeoxford-com"
 # ENVIRONMENT           - Deployment environment (production/staging)
 
 [secrets]
-# AI Search is currently stored under this legacy secret name; the route reads
-# it through bracket notation until the credential can be rotated safely.
-required = ["TURNSTILE_SECRET_KEY", "search-api"]
+# Keep the required declaration aligned with the deployed secret name. The
+# route retains a legacy fallback for backwards compatibility during rotation.
+required = ["TURNSTILE_SECRET_KEY", "AI_SEARCH_API_TOKEN"]
 
 [vars]
 # Public variables (not sensitive)


### PR DESCRIPTION
## What changed
- Updated `wrangler.toml` to require the deployed `AI_SEARCH_API_TOKEN` secret.
- Retained the legacy secret fallback in the AI Search route for controlled rotation compatibility.

## Why
Cloudflare Workers Builds completed installation and the Astro build, then failed during `npx wrangler deploy` because the configuration required the absent legacy secret `search-api`.

## Impact
- Restores the Cloudflare Workers Builds production deploy path without rotating or exposing secrets.
- No runtime bindings, public variables, or application behavior changed.
- The change is limited to one configuration declaration and is directly reversible.

## Testing
- `pnpm run build`
- `bash scripts/build/deployment-check.sh`
- `wrangler deploy --dry-run`

## Screenshots
- Not applicable; configuration-only fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to the required secrets list; runtime behavior is unchanged because the route already reads `AI_SEARCH_API_TOKEN` with a legacy fallback.
> 
> **Overview**
> **Fixes Cloudflare Workers deploy** by aligning `[secrets].required` with the secret name actually set in production.
> 
> The required list now includes **`AI_SEARCH_API_TOKEN`** instead of the legacy **`search-api`** name that was missing and caused `wrangler deploy` to fail after a successful build. Comments were updated to note that the AI Search route still falls back to the old secret name during rotation.
> 
> No application logic, bindings, or public vars change—only the deploy-time secret declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22311387c59b2565d8c91f163044deb46d017ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required configuration secret name for AI-powered search.
  * Retained compatibility with the legacy secret during credential rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->