### PR TITLE
fix(cloudflare): remove legacy AI search secret fallback

### DIFF
--- a/functions/routes/ai-search/index.ts
+++ b/functions/routes/ai-search/index.ts
@@ -2,7 +2,6 @@ import { anonymizeClientIp } from '../../shared/ip';
 import { buildApiCorsHeaders } from '../../shared/cors';
 import { writeAiAnalytics } from '../../shared/ai-analytics';
 import type { RouteContext } from '../../shared/route-context';
-import type { Env } from '../../types';
 import { parseAiSources } from './parse-sources';
 import { checkAiSearchRateLimit } from './rate-limit';
 import {

--- a/functions/routes/ai-search/index.ts
+++ b/functions/routes/ai-search/index.ts
@@ -211,8 +211,7 @@ export async function handleAiSearch({
   }
 
   const upstreamEndpoint = env.AI_SEARCH_API_ENDPOINT;
-  const upstreamToken =
-    env.AI_SEARCH_API_TOKEN || (env as Env & { 'search-api'?: string })['search-api'];
+  const upstreamToken = env.AI_SEARCH_API_TOKEN;
 
   const wantsStream =
     payload.stream === true ||

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -63,8 +63,7 @@ script_name = "blakeoxford-com"
 # ENVIRONMENT           - Deployment environment (production/staging)
 
 [secrets]
-# Keep the required declaration aligned with the deployed secret name. The
-# route retains a legacy fallback for backwards compatibility during rotation.
+# Keep the required declaration aligned with the deployed secret name.
 required = ["TURNSTILE_SECRET_KEY", "AI_SEARCH_API_TOKEN"]
 
 [vars]


### PR DESCRIPTION
## What changed
- Removed the legacy `search-api` fallback from the AI Search Worker route.
- Kept `AI_SEARCH_API_TOKEN` as the sole configured upstream credential.
- Removed the stale fallback note from `wrangler.toml`.
- Removed the unused `Env` type import exposed by the cleanup.

## Why
The production Worker has only `AI_SEARCH_API_TOKEN`; retaining the old fallback created configuration drift and could mask secret-name mistakes.

## Impact
- AI Search uses the canonical secret only.
- No public API shape, bindings, or secret values changed.
- If the canonical secret is missing, the existing bounded 503 response remains.

## Testing
- `pnpm exec vitest run tests/vitest/aiSearchMeta.test.ts tests/vitest/edge/search-inputs.edge.test.ts` (6 tests passed)
- `pnpm exec eslint functions/routes/ai-search/index.ts`
- `pnpm run typecheck`
- `pnpm run build`
- `bash scripts/build/deployment-check.sh`
- `wrangler deploy --dry-run`
- GitHub Fast CI, security/dependency, analysis, deployment readiness, and Cloudflare Workers Build checks

## Screenshots
- Not applicable; Worker configuration/code cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small config cleanup on a single route with unchanged API behavior; misconfigured deploys still fail fast with 503 instead of silently using a wrong secret name.
> 
> **Overview**
> The AI Search Worker route now reads **`AI_SEARCH_API_TOKEN` only** for upstream AutoRAG auth; the old **`search-api` secret fallback** and the related **`Env` cast** are gone.
> 
> **`wrangler.toml`** comments no longer describe rotation/backwards compatibility for that legacy name. Missing endpoint or token still yields the same **503** “not configured” response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf0746142a2ac0ab49e93d44c7e9b010962113e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->