### PR TITLE
feat(cloudflare): migrate AI Search and add scheduled canary

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -803,9 +803,10 @@ pnpm exec wrangler tail  # View live logs
 
 **AI features not working**:
 ```bash
-# Check environment variables
-echo $AI_SEARCH_API_TOKEN
-echo $AI_SEARCH_API_ENDPOINT
+# Check secret names only; never print secret values
+pnpm exec wrangler secret list --name blakeoxford-com
+# The endpoint is non-secret and is defined in wrangler.toml.
+rg -n "AI_SEARCH_API_ENDPOINT" wrangler.toml
 
 # Test locally with dev proxy
 pnpm dev

--- a/.github/instructions/ai-features.instructions.md
+++ b/.github/instructions/ai-features.instructions.md
@@ -347,7 +347,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 Required for AI features:
 
-- `AI_SEARCH_API_ENDPOINT` - Vectorize endpoint
+- `AI_SEARCH_API_ENDPOINT` - Cloudflare AI Search Chat Completions endpoint
 - `AI_SEARCH_API_TOKEN` - Authentication token
 - `PUBLIC_ENABLE_AI_CHAT` - Feature flag
 

--- a/.github/instructions/cloudflare.instructions.md
+++ b/.github/instructions/cloudflare.instructions.md
@@ -285,7 +285,8 @@ In `wrangler.toml`:
 
 ```toml
 [vars]
-AI_SEARCH_API_ENDPOINT = "https://..."
+# Current Cloudflare AI Search Chat Completions endpoint.
+AI_SEARCH_API_ENDPOINT = "https://.../ai-search/instances/.../chat/completions"
 ENVIRONMENT = "production"
 ```
 

--- a/docs/operations/cloudflare-monitoring.md
+++ b/docs/operations/cloudflare-monitoring.md
@@ -5,6 +5,12 @@ Worker `blakeoxford-com`. It uses Cloudflare Synthetic Monitoring, Cloudflare
 native observability, Sentry, and the local smoke script. No additional
 monitoring vendor or secret is required.
 
+The Worker now uses Cloudflare's current AI Search Chat Completions REST
+endpoint (`/ai-search/instances/.../chat/completions`) with the dedicated
+`AI_SEARCH_API_TOKEN` secret. The public `/api/ai-search` response and SSE
+contract remain unchanged. The prior AutoRAG endpoint remains the rollback
+target if the new upstream contract has an incident.
+
 Cloudflare Health Checks are intentionally not configured: the current
 `blakeoxford.com` zone is on the Free plan, and the dashboard requires Pro /
 Smart Shield for that feature. Do not upgrade billing or weaken existing
@@ -57,6 +63,8 @@ protection` rule is active.
 5. Review trace volume and sampling. Current production sampling is 5%; keep
    it bounded unless the extra diagnostic value is justified.
 6. Verify the previous Worker deployment remains available for rollback.
+7. Confirm the AI Search route returns a non-empty message and that streamed
+   requests emit `ready`, `token`, and `done` events.
 
 ## Failure handling
 
@@ -72,6 +80,9 @@ protection` rule is active.
   threshold.
 - **Secret failure:** disable the affected feature or route, rotate the secret,
   redeploy through the normal branch flow, and retest the route.
+- **AI Search contract failure:** restore the prior AutoRAG endpoint in
+  `AI_SEARCH_API_ENDPOINT`, redeploy the last known-good code version, and
+  validate both JSON and SSE responses before investigating a second cutover.
 
 ## Kill switches and rollback
 

--- a/docs/operations/cloudflare-monitoring.md
+++ b/docs/operations/cloudflare-monitoring.md
@@ -11,6 +11,10 @@ endpoint (`/ai-search/instances/.../chat/completions`) with the dedicated
 contract remain unchanged. The prior AutoRAG endpoint remains the rollback
 target if the new upstream contract has an incident.
 
+An every-six-hours Cron Trigger runs a fixed, timestamped AI Search canary. It
+records only success/error, latency, and response length in Analytics Engine;
+it does not include user prompts or response text.
+
 Cloudflare Health Checks are intentionally not configured: the current
 `blakeoxford.com` zone is on the Free plan, and the dashboard requires Pro /
 Smart Shield for that feature. Do not upgrade billing or weaken existing
@@ -65,6 +69,8 @@ protection` rule is active.
 6. Verify the previous Worker deployment remains available for rollback.
 7. Confirm the AI Search route returns a non-empty message and that streamed
    requests emit `ready`, `token`, and `done` events.
+8. Review scheduled canary failures and latency in Workers Logs/Sentry and the
+   `ai_search_canary` Analytics Engine index.
 
 ## Failure handling
 
@@ -94,6 +100,9 @@ protection` rule is active.
   `cac8413d409f444eaef771183818a449`.
 - **Traces:** set `[observability.traces].enabled = false` and redeploy if
   trace volume or cost becomes abnormal.
+- **Scheduled canary:** remove the `[triggers]` block from `wrangler.toml` and
+  redeploy. This disables only the canary; it does not disable AI Search or
+  public traffic.
 
 Never place secret values, client IPs, request bodies, or contact-form content
 in this runbook, workflow output, or incident notes.

--- a/docs/operations/cloudflare-monitoring.md
+++ b/docs/operations/cloudflare-monitoring.md
@@ -5,6 +5,14 @@ Worker `blakeoxford-com`. It uses Cloudflare Synthetic Monitoring, Cloudflare
 native observability, Sentry, and the local smoke script. No additional
 monitoring vendor or secret is required.
 
+Cloudflare Health Checks are intentionally not configured: the current
+`blakeoxford.com` zone is on the Free plan, and the dashboard requires Pro /
+Smart Shield for that feature. Do not upgrade billing or weaken existing
+protections to create a duplicate check. The approved Free-plan availability
+signal is the weekly Synthetic Monitoring test plus the local edge smoke
+script; an email alert for Health Check status changes does not currently
+exist.
+
 ## Signals and owners
 
 | Signal            | Leading indicator                           | Action threshold                                           | Owner                 |

--- a/docs/operations/cloudflare-monitoring.md
+++ b/docs/operations/cloudflare-monitoring.md
@@ -51,7 +51,7 @@ protection` rule is active.
    and blocked-event volume. Change it only with a documented reason and a
    rollback value.
 3. Confirm required secrets exist without printing their values:
-   `TURNSTILE_SECRET_KEY` and the legacy `search-api` credential.
+   `TURNSTILE_SECRET_KEY` and `AI_SEARCH_API_TOKEN`.
 4. Rotate a secret if it may have been exposed, its owner is unclear, or its
    provider requires rotation. Validate the affected route immediately after.
 5. Review trace volume and sampling. Current production sampling is 5%; keep

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -17,6 +17,7 @@ import { handleTheme } from './routes/theme';
 import { handleLegacySearchRedirect } from './routes/legacy-search-redirect';
 import { handleDebug } from './routes/debug';
 import { handleAssets } from './routes/assets';
+import { runAiSearchCanary } from './scheduled/ai-search-canary';
 
 export { ConversationDurableObject } from './ConversationDO.ts';
 
@@ -53,6 +54,20 @@ function applySecurityHeaders(response: Response, reqId: string, hostname: strin
 }
 
 const WorkerApp = {
+  async scheduled(controller: ScheduledController, env: Env): Promise<void> {
+    const Sentry = initEdgeSentry(env);
+    try {
+      await runAiSearchCanary(env, controller.scheduledTime);
+    } catch (error) {
+      controller.noRetry();
+      Sentry.captureException(error, {
+        tags: { runtime: 'scheduled', check: 'ai-search-canary' },
+      });
+      console.error('AI Search scheduled canary failed', error);
+      throw error;
+    }
+  },
+
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const Sentry = initEdgeSentry(env);
     const url = new URL(request.url);

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -53,6 +53,10 @@ function applySecurityHeaders(response: Response, reqId: string, hostname: strin
   });
 }
 
+export function isProductionScheduledPath(pathname: string, environment?: string): boolean {
+  return environment === 'production' && pathname === '/__scheduled';
+}
+
 const WorkerApp = {
   async scheduled(controller: ScheduledController, env: Env): Promise<void> {
     const Sentry = initEdgeSentry(env);
@@ -78,6 +82,17 @@ const WorkerApp = {
 
     const method = request.method || 'GET';
     const reqId = generateRequestId(request);
+
+    if (isProductionScheduledPath(url.pathname, env.ENVIRONMENT)) {
+      return applySecurityHeaders(
+        new Response('Not Found', {
+          status: 404,
+          headers: { 'cache-control': 'no-store', 'x-route-kind': 'blocked-internal' },
+        }),
+        reqId,
+        url.hostname
+      );
+    }
 
     // HTTPS + apex canonicalization
     try {

--- a/functions/routes/ai-search/index.ts
+++ b/functions/routes/ai-search/index.ts
@@ -211,8 +211,7 @@ export async function handleAiSearch({
   }
 
   const upstreamEndpoint = env.AI_SEARCH_API_ENDPOINT;
-  const upstreamToken =
-    env.AI_SEARCH_API_TOKEN || (env as Env & { 'search-api'?: string })['search-api'];
+  const upstreamToken = env.AI_SEARCH_API_TOKEN;
 
   const wantsStream =
     payload.stream === true ||

--- a/functions/routes/ai-search/index.ts
+++ b/functions/routes/ai-search/index.ts
@@ -2,7 +2,6 @@ import { anonymizeClientIp } from '../../shared/ip';
 import { buildApiCorsHeaders } from '../../shared/cors';
 import { writeAiAnalytics } from '../../shared/ai-analytics';
 import type { RouteContext } from '../../shared/route-context';
-import type { Env } from '../../types';
 import { parseAiSources } from './parse-sources';
 import { checkAiSearchRateLimit } from './rate-limit';
 import {
@@ -19,6 +18,12 @@ import {
   parsePageContext,
   type AiSearchPayload,
 } from './types';
+import {
+  buildAiSearchRequest,
+  extractAiSearchError,
+  extractAiSearchMessage,
+  extractAiSearchSourceData,
+} from './upstream';
 import { handleSimpleQueryWithWorkersAI, looksLikeEmptyRetrieval } from './workers-ai';
 
 const MAX_REQUEST_BYTES = 32 * 1024;
@@ -225,9 +230,9 @@ export async function handleAiSearch({
   }
 
   try {
-    const requestBody = { query: enhancedQuery, history };
+    const requestBody = buildAiSearchRequest(enhancedQuery, history);
 
-    // AutoRAG stays on the direct AI Search endpoint — do not attach AI Gateway
+    // AI Search stays on the direct endpoint — do not attach AI Gateway
     // cache headers here (index/retrieval caching fights freshness). Workers AI
     // observability goes through env.AI.run gateway options in workers-ai.ts.
     const fetchUrl = upstreamEndpoint;
@@ -246,13 +251,10 @@ export async function handleAiSearch({
     if (!upstreamResponse.ok) {
       let errorDetail = 'Upstream service error';
       try {
-        const upstreamError = (await upstreamResponse.json()) as { error?: unknown };
-        if (typeof upstreamError?.error === 'string') {
-          errorDetail = upstreamError.error;
-        }
+        const upstreamError = await upstreamResponse.json();
+        errorDetail = extractAiSearchError(upstreamError) || errorDetail;
       } catch {
-        const upstreamText = await upstreamResponse.text();
-        if (upstreamText) errorDetail = upstreamText.slice(0, 200);
+        // Keep the public error bounded and generic if the provider sends invalid JSON.
       }
       return new Response(JSON.stringify({ error: errorDetail }), {
         status: upstreamResponse.status,
@@ -275,27 +277,18 @@ export async function handleAiSearch({
       const firstError =
         errors[0] && typeof errors[0] === 'object' ? (errors[0] as { message?: unknown }) : null;
       const upstreamError =
-        typeof firstError?.message === 'string'
+        extractAiSearchError(upstreamData) ||
+        (typeof firstError?.message === 'string'
           ? firstError.message
-          : 'AI search service reported an error';
+          : 'AI search service reported an error');
       return new Response(JSON.stringify({ error: upstreamError }), {
         status: 502,
         headers: baseCorsHeaders,
       });
     }
 
-    const result =
-      upstreamData.result && typeof upstreamData.result === 'object'
-        ? (upstreamData.result as Record<string, unknown>)
-        : upstreamData;
-    const message =
-      typeof result.response === 'string'
-        ? result.response.trim()
-        : typeof upstreamData.response === 'string'
-          ? upstreamData.response.trim()
-          : '';
-
-    const resultData = Array.isArray(result.data) ? result.data : [];
+    const message = extractAiSearchMessage(upstreamData);
+    const resultData = extractAiSearchSourceData(upstreamData);
     const sources = parseAiSources(resultData);
 
     if (!message) {

--- a/functions/routes/ai-search/parse-sources.ts
+++ b/functions/routes/ai-search/parse-sources.ts
@@ -14,21 +14,45 @@ export function parseAiSources(resultData: unknown[]): AiSourcePayload[] {
         attributes.file && typeof attributes.file === 'object'
           ? (attributes.file as Record<string, unknown>)
           : {};
+      const item =
+        entryObj.item && typeof entryObj.item === 'object'
+          ? (entryObj.item as Record<string, unknown>)
+          : {};
+      const itemMetadata =
+        item.metadata && typeof item.metadata === 'object'
+          ? (item.metadata as Record<string, unknown>)
+          : {};
       const rawUrl =
         typeof entryObj.filename === 'string' && entryObj.filename
           ? entryObj.filename
           : typeof attributes.folder === 'string'
             ? attributes.folder
-            : '';
+            : typeof itemMetadata.url === 'string'
+              ? itemMetadata.url
+              : typeof itemMetadata.pathname === 'string'
+                ? itemMetadata.pathname
+                : typeof itemMetadata.source_url === 'string'
+                  ? itemMetadata.source_url
+                  : typeof itemMetadata.sourceUrl === 'string'
+                    ? itemMetadata.sourceUrl
+                    : typeof itemMetadata.path === 'string'
+                      ? itemMetadata.path
+                      : typeof item.key === 'string'
+                        ? item.key
+                        : '';
       if (!rawUrl) return null;
       const titleCandidate =
         typeof fileMeta.title === 'string' && fileMeta.title.trim()
           ? fileMeta.title.trim()
           : typeof attributes.folder === 'string' && attributes.folder.trim()
             ? attributes.folder.trim()
-            : `Source ${index + 1}`;
+            : typeof itemMetadata.title === 'string' && itemMetadata.title.trim()
+              ? itemMetadata.title.trim()
+              : `Source ${index + 1}`;
       let snippet: string | undefined;
-      if (Array.isArray(entryObj.content)) {
+      if (typeof entryObj.text === 'string' && entryObj.text.trim()) {
+        snippet = entryObj.text.trim().slice(0, 320);
+      } else if (Array.isArray(entryObj.content)) {
         const contentItem = entryObj.content.find(
           (item: unknown) =>
             !!item &&
@@ -41,7 +65,16 @@ export function parseAiSources(resultData: unknown[]): AiSourcePayload[] {
         }
       }
       const score = typeof entryObj.score === 'number' ? entryObj.score : undefined;
-      const metadata = buildSourceMetadata(rawUrl, entryObj);
+      const metadata = buildSourceMetadata(rawUrl, {
+        ...entryObj,
+        attributes: {
+          ...attributes,
+          metadata: {
+            ...((attributes.metadata as Record<string, unknown> | undefined) || {}),
+            ...itemMetadata,
+          },
+        },
+      });
       const sourcePayload: AiSourcePayload = {
         title: titleCandidate,
         url: rawUrl,

--- a/functions/routes/ai-search/types.ts
+++ b/functions/routes/ai-search/types.ts
@@ -13,13 +13,12 @@ export type AiSearchPayload = {
 
 export type PageContext = { title: string; pathname: string; url: string } | null;
 
-export type HistoryEntry = { role: string; content: string };
+export type HistoryEntry = { role: 'user' | 'assistant'; content: string };
 
 export type RateLimitBucket = { count: number; reset: number };
 
 export type RateLimitResult =
-  | { limited: false }
-  | { limited: true; reason: string; resetIn: number };
+  { limited: false } | { limited: true; reason: string; resetIn: number };
 
 export type CachedAiResponse = {
   message?: string;
@@ -74,7 +73,7 @@ export function parseHistory(raw: unknown): HistoryEntry[] {
       (entry): entry is HistoryEntry =>
         !!entry &&
         typeof entry === 'object' &&
-        typeof (entry as HistoryEntry).role === 'string' &&
+        ((entry as HistoryEntry).role === 'user' || (entry as HistoryEntry).role === 'assistant') &&
         typeof (entry as HistoryEntry).content === 'string'
     )
     .slice(-10);

--- a/functions/routes/ai-search/upstream.ts
+++ b/functions/routes/ai-search/upstream.ts
@@ -1,0 +1,61 @@
+import type { HistoryEntry } from './types';
+
+type AiSearchMessage = { role: 'user' | 'assistant'; content: string };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function extractChoiceMessage(value: unknown): string {
+  const choice = asRecord(value);
+  const message = asRecord(choice?.message);
+  const content = message?.content;
+  if (typeof content === 'string') return content.trim();
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) => {
+      const partRecord = asRecord(part);
+      return typeof partRecord?.text === 'string' ? partRecord.text : '';
+    })
+    .join('')
+    .trim();
+}
+
+export function buildAiSearchRequest(query: string, history: HistoryEntry[]) {
+  const messages: AiSearchMessage[] = [
+    ...history.map(({ role, content }) => ({ role, content })),
+    { role: 'user', content: query },
+  ];
+  return { messages };
+}
+
+export function extractAiSearchMessage(payload: Record<string, unknown>): string {
+  const choices = Array.isArray(payload.choices) ? payload.choices : [];
+  const chatMessage = extractChoiceMessage(choices[0]);
+  if (chatMessage) return chatMessage;
+
+  const result = asRecord(payload.result);
+  const resultResponse = result?.response;
+  if (typeof resultResponse === 'string') return resultResponse.trim();
+
+  return typeof payload.response === 'string' ? payload.response.trim() : '';
+}
+
+export function extractAiSearchSourceData(payload: Record<string, unknown>): unknown[] {
+  const result = asRecord(payload.result);
+  if (Array.isArray(result?.data)) return result.data;
+  if (Array.isArray(result?.chunks)) return result.chunks;
+  if (Array.isArray(payload.chunks)) return payload.chunks;
+  return [];
+}
+
+export function extractAiSearchError(payload: unknown): string | undefined {
+  const record = asRecord(payload);
+  if (!record) return undefined;
+  if (typeof record.error === 'string' && record.error.trim()) return record.error.trim();
+  const errors = Array.isArray(record.errors) ? record.errors : [];
+  const firstError = asRecord(errors[0]);
+  return typeof firstError?.message === 'string' && firstError.message.trim()
+    ? firstError.message.trim()
+    : undefined;
+}

--- a/functions/scheduled/ai-search-canary.ts
+++ b/functions/scheduled/ai-search-canary.ts
@@ -1,0 +1,62 @@
+import type { Env } from '../types';
+import { writeAiAnalytics } from '../shared/ai-analytics';
+
+const CANARY_URL = 'https://blakeoxford.com/api/ai-search';
+const CANARY_TIMEOUT_MS = 25_000;
+
+type CanaryEnv = Pick<Env, 'AI_ANALYTICS'>;
+type CanaryFetcher = typeof fetch;
+
+export type AiSearchCanaryResult = {
+  latencyMs: number;
+  messageLength: number;
+};
+
+export async function runAiSearchCanary(
+  env: CanaryEnv,
+  scheduledTime: number,
+  fetcher: CanaryFetcher = globalThis.fetch
+): Promise<AiSearchCanaryResult> {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CANARY_TIMEOUT_MS);
+  const query = `Cloudflare AI Search canary ${new Date(scheduledTime).toISOString()}`;
+
+  try {
+    const response = await fetcher(CANARY_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-session-id': 'scheduled-canary' },
+      body: JSON.stringify({ query }),
+      signal: controller.signal,
+    });
+    const latencyMs = Date.now() - startedAt;
+
+    if (!response.ok) {
+      throw new Error(`AI Search canary returned HTTP ${response.status}`);
+    }
+
+    const payload = (await response.json()) as { message?: unknown };
+    const messageLength = typeof payload.message === 'string' ? payload.message.trim().length : 0;
+    if (messageLength === 0) {
+      throw new Error('AI Search canary returned no message');
+    }
+
+    writeAiAnalytics(env, {
+      blobs: ['scheduled_canary', 'ok'],
+      doubles: [latencyMs, messageLength],
+      indexes: ['ai_search_canary'],
+    });
+
+    return { latencyMs, messageLength };
+  } catch (error) {
+    const latencyMs = Date.now() - startedAt;
+    writeAiAnalytics(env, {
+      blobs: ['scheduled_canary', 'error'],
+      doubles: [latencyMs, 0],
+      indexes: ['ai_search_canary'],
+    });
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "typescript": "^6.0.3",
     "vite": "8.1.5",
     "vitest": "^4.1.10",
-    "wrangler": "^4.111.0"
+    "wrangler": "^4.118.0"
   },
   "packageManager": "pnpm@10.34.5+sha256.ccb5c479cab1b00621325bfe7d4c9a8a8031e7a525d7249e275ecbec81b08db2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,8 +198,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(yaml@2.8.3))
       wrangler:
-        specifier: ^4.111.0
-        version: 4.111.0(@types/node@26.1.1)
+        specifier: ^4.118.0
+        version: 4.118.0(@types/node@26.1.1)
 
 packages:
 
@@ -543,32 +543,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260710.1':
-    resolution: {integrity: sha512-OqJl2eWF5+y9jarMm3YqqCTUe7Hd4ihogX5jyRU8iaAgOVyDr/Bk6aXpPCVUi1/MHzO93a18R/TmSTtzmB0sQw==}
+  '@cloudflare/workerd-darwin-64@1.20260730.1':
+    resolution: {integrity: sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260710.1':
-    resolution: {integrity: sha512-MYBqWgUblO+VlGvO73zYsH3hB9tdRj+yLyt5IHDFWryipb2l1efmNiWtAOkIhSRfypqLYGFrfpaDm2Hg00XVKw==}
+  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
+    resolution: {integrity: sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260710.1':
-    resolution: {integrity: sha512-lVWUgqI8qrkqvaCBGElu1kdaUFdAvaS2RD8K4qkCFP9hI3f5TCXumEs5qWSeZkvKum0+X/uJZ5hBFWsYI5SmoQ==}
+  '@cloudflare/workerd-linux-64@1.20260730.1':
+    resolution: {integrity: sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260710.1':
-    resolution: {integrity: sha512-kDwDPItBjAI4JL0df9Fma2N+Qggbm77IB/DnroAkEGQ79fpR80sYMyuB/ZQKyjEk9f48Ocq7HCCLq59qVSyNqA==}
+  '@cloudflare/workerd-linux-arm64@1.20260730.1':
+    resolution: {integrity: sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260710.1':
-    resolution: {integrity: sha512-GcLHy1oN1dfK6g1Z7UDV9f5xMGyTfPwcjWQ0sfWKH31IsoEVCRapnj3IC0PoIrDbnoo6irGPP0CwVs3WzdTajw==}
+  '@cloudflare/workerd-windows-64@1.20260730.1':
+    resolution: {integrity: sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -1851,8 +1851,8 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@speed-highlight/core@1.2.17':
-    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
+  '@speed-highlight/core@1.2.23':
+    resolution: {integrity: sha512-iRoq6i6JDJP6Mt2A5JaPvzw0pgYHH6k92ij+yXiTrB7T2y9N789aWE3EHWj/5ztlJBokcCBja3iYLVdu5wgnkg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -4529,10 +4529,9 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  miniflare@4.20260710.0:
-    resolution: {integrity: sha512-x1LLRkU6o1p7hiKrB0TRnL0MJn6xFOT+/vrlEQINz5cRDKLP8ru4hBqWTIvXAetzr1acKAnmAaG84pQ4W/K14g==}
+  miniflare@5.20260730.0-alpha:
+    resolution: {integrity: sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==}
     engines: {node: '>=22.0.0'}
-    hasBin: true
 
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
@@ -6376,17 +6375,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20260710.1:
-    resolution: {integrity: sha512-U2sBPPrb9U97sBKnnMN6Kv8p65903P35nwMkPE9vSH/bRuRqkZ3a1EjUw3jV28RhiyXpkLF77Evzw8XimFxyTw==}
+  workerd@1.20260730.1:
+    resolution: {integrity: sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.111.0:
-    resolution: {integrity: sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ==}
+  wrangler@4.118.0:
+    resolution: {integrity: sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260710.1
+      '@cloudflare/workers-types': ^5.20260730.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -6982,25 +6981,25 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260710.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260710.1
+      workerd: 1.20260730.1
 
-  '@cloudflare/workerd-darwin-64@1.20260710.1':
+  '@cloudflare/workerd-darwin-64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260710.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260710.1':
+  '@cloudflare/workerd-linux-64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260710.1':
+  '@cloudflare/workerd-linux-arm64@1.20260730.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260710.1':
+  '@cloudflare/workerd-windows-64@1.20260730.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -8317,7 +8316,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@speed-highlight/core@1.2.17': {}
+  '@speed-highlight/core@1.2.23': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -11762,12 +11761,12 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  miniflare@4.20260710.0(@types/node@26.1.1):
+  miniflare@5.20260730.0-alpha(@types/node@26.1.1):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@26.1.1)
       undici: 7.28.0
-      workerd: 1.20260710.1
+      workerd: 1.20260730.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -13790,24 +13789,24 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20260710.1:
+  workerd@1.20260730.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260710.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260710.1
-      '@cloudflare/workerd-linux-64': 1.20260710.1
-      '@cloudflare/workerd-linux-arm64': 1.20260710.1
-      '@cloudflare/workerd-windows-64': 1.20260710.1
+      '@cloudflare/workerd-darwin-64': 1.20260730.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260730.1
+      '@cloudflare/workerd-linux-64': 1.20260730.1
+      '@cloudflare/workerd-linux-arm64': 1.20260730.1
+      '@cloudflare/workerd-windows-64': 1.20260730.1
 
-  wrangler@4.111.0(@types/node@26.1.1):
+  wrangler@4.118.0(@types/node@26.1.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260710.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 4.20260710.0(@types/node@26.1.1)
+      miniflare: 5.20260730.0-alpha(@types/node@26.1.1)
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260710.1
+      workerd: 1.20260730.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
@@ -13958,7 +13957,7 @@ snapshots:
     dependencies:
       '@poppinss/colors': 4.1.6
       '@poppinss/dumper': 0.6.5
-      '@speed-highlight/core': 1.2.17
+      '@speed-highlight/core': 1.2.23
       cookie: 1.1.1
       youch-core: 0.3.3
 

--- a/tests/vitest/aiSearchCanary.test.ts
+++ b/tests/vitest/aiSearchCanary.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runAiSearchCanary } from '../../functions/scheduled/ai-search-canary';
+
+function analyticsEnv() {
+  return {
+    AI_ANALYTICS: {
+      writeDataPoint: vi.fn(),
+    },
+  } as never;
+}
+
+describe('AI Search scheduled canary', () => {
+  it('records a successful response without recording prompt or answer text', async () => {
+    const env = analyticsEnv();
+    const result = await runAiSearchCanary(
+      env,
+      Date.parse('2026-08-02T18:00:00.000Z'),
+      vi.fn(async () => new Response(JSON.stringify({ message: 'canary answer' }), { status: 200 }))
+    );
+
+    expect(result.messageLength).toBe(13);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(env.AI_ANALYTICS.writeDataPoint).toHaveBeenCalledWith({
+      blobs: ['scheduled_canary', 'ok'],
+      doubles: expect.arrayContaining([13]),
+      indexes: ['ai_search_canary'],
+    });
+  });
+
+  it('fails closed when the provider returns an error', async () => {
+    const env = analyticsEnv();
+    await expect(
+      runAiSearchCanary(
+        env,
+        Date.now(),
+        vi.fn(async () => new Response('{}', { status: 503 }))
+      )
+    ).rejects.toThrow('HTTP 503');
+
+    expect(env.AI_ANALYTICS.writeDataPoint).toHaveBeenCalledWith({
+      blobs: ['scheduled_canary', 'error'],
+      doubles: expect.any(Array),
+      indexes: ['ai_search_canary'],
+    });
+  });
+
+  it('fails when a successful provider response has no message', async () => {
+    await expect(
+      runAiSearchCanary(
+        analyticsEnv(),
+        Date.now(),
+        vi.fn(async () => new Response(JSON.stringify({ sources: [] }), { status: 200 }))
+      )
+    ).rejects.toThrow('returned no message');
+  });
+});

--- a/tests/vitest/aiSearchUpstream.test.ts
+++ b/tests/vitest/aiSearchUpstream.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { parseAiSources } from '../../functions/routes/ai-search/parse-sources';
+import {
+  buildAiSearchRequest,
+  extractAiSearchError,
+  extractAiSearchMessage,
+  extractAiSearchSourceData,
+} from '../../functions/routes/ai-search/upstream';
+
+describe('Cloudflare AI Search upstream adapter', () => {
+  it('builds the new chat-completions request from bounded conversation history', () => {
+    expect(
+      buildAiSearchRequest('current question', [
+        { role: 'user', content: 'earlier question' },
+        { role: 'assistant', content: 'earlier answer' },
+      ])
+    ).toEqual({
+      messages: [
+        { role: 'user', content: 'earlier question' },
+        { role: 'assistant', content: 'earlier answer' },
+        { role: 'user', content: 'current question' },
+      ],
+    });
+  });
+
+  it('extracts the new chat response and chunks', () => {
+    const payload = {
+      choices: [{ message: { role: 'assistant', content: '  New answer  ' } }],
+      chunks: [
+        {
+          id: 'chunk-1',
+          text: 'source text',
+          score: 0.9,
+          item: { key: '/projects/example', metadata: { title: 'Example project' } },
+        },
+      ],
+    };
+
+    expect(extractAiSearchMessage(payload)).toBe('New answer');
+    expect(extractAiSearchSourceData(payload)).toEqual(payload.chunks);
+    expect(parseAiSources(payload.chunks)).toEqual([
+      {
+        title: 'Example project',
+        url: '/projects/example',
+        snippet: 'source text',
+        score: 0.9,
+        collection: 'Project',
+        icon: '🛠️',
+      },
+    ]);
+  });
+
+  it('keeps legacy AutoRAG responses readable during rollback', () => {
+    const payload = {
+      result: {
+        response: 'Legacy answer',
+        data: [{ filename: '/projects/example', score: 0.8 }],
+      },
+    };
+
+    expect(extractAiSearchMessage(payload)).toBe('Legacy answer');
+    expect(extractAiSearchSourceData(payload)).toEqual(payload.result.data);
+  });
+
+  it('extracts provider errors without exposing unrelated response fields', () => {
+    expect(extractAiSearchError({ errors: [{ message: 'permission denied' }] })).toBe(
+      'permission denied'
+    );
+    expect(extractAiSearchError({ error: 'bad request', token: 'redacted' })).toBe('bad request');
+    expect(extractAiSearchError({ errors: [{ code: 1000 }] })).toBeUndefined();
+  });
+});

--- a/tests/vitest/edge/worker.edge.test.ts
+++ b/tests/vitest/edge/worker.edge.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { isProductionScheduledPath } from '../../../functions/index';
+
+describe('production scheduled endpoint hardening', () => {
+  it('blocks the local scheduled trigger endpoint in production', () => {
+    expect(isProductionScheduledPath('/__scheduled', 'production')).toBe(true);
+  });
+
+  it('does not block the path outside production', () => {
+    expect(isProductionScheduledPath('/__scheduled', 'development')).toBe(false);
+    expect(isProductionScheduledPath('/healthz', 'production')).toBe(false);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,6 +10,11 @@ compatibility_flags = ["nodejs_compat"]
 main = "functions/index.ts"
 workers_dev = false
 
+# Low-frequency canary for the public AI Search route. Remove this block and
+# redeploy to disable the scheduled check without affecting request traffic.
+[triggers]
+crons = ["0 */6 * * *"]
+
 [assets]
 binding = "ASSETS"
 directory = "./dist"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -63,9 +63,7 @@ script_name = "blakeoxford-com"
 # ENVIRONMENT           - Deployment environment (production/staging)
 
 [secrets]
-# AI Search is currently stored under this legacy secret name; the route reads
-# it through bracket notation until the credential can be rotated safely.
-required = ["TURNSTILE_SECRET_KEY", "search-api"]
+required = ["TURNSTILE_SECRET_KEY", "AI_SEARCH_API_TOKEN"]
 
 [vars]
 # Public variables (not sensitive)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -69,7 +69,7 @@ required = ["TURNSTILE_SECRET_KEY", "AI_SEARCH_API_TOKEN"]
 # Public variables (not sensitive)
 # Add ENVIRONMENT variable for Sentry context
 ENVIRONMENT = "production"
-AI_SEARCH_API_ENDPOINT = "https://api.cloudflare.com/client/v4/accounts/cc3bb24ae3c87cff38c2be85df3dab29/autorag/rags/bold-heart-18e4/ai-search"
+AI_SEARCH_API_ENDPOINT = "https://api.cloudflare.com/client/v4/accounts/cc3bb24ae3c87cff38c2be85df3dab29/ai-search/instances/bold-heart-18e4/chat/completions"
 PUBLIC_CLARITY_PROJECT_ID = "tqngpokfgs"
 
 # AI Gateway for Workers AI (`env.AI.run` in workers-ai.ts).


### PR DESCRIPTION
## What changed

- Migrate the AI Search route to the current Chat Completions upstream contract.
- Add bounded response/source/error adapters and focused tests.
- Add a six-hour scheduled AI Search canary with Analytics Engine observability.
- Block public access to the internal scheduled path.
- Align the required AI Search secret contract and document rollback/kill-switch behavior.

## Why

The current provider contract and secret naming needed to be explicit and testable. The canary provides a low-frequency production signal without logging prompts or response text.

## Impact

This changes the Worker AI Search upstream request/response contract and adds a scheduled trigger. Public `/api/ai-search` JSON/SSE contracts remain unchanged.

## Validation

- Focused Vitest: 3 files, 9 tests passed.
- `git diff --check` clean.
- Existing main CodeQL findings are pre-existing and outside this change set; they remain tracked separately.

## Rollback

Restore the prior AI Search endpoint/token configuration and redeploy the last known-good Worker. Remove the `[triggers]` block to disable only the scheduled canary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production AI Search upstream auth, request body, and response parsing; misconfiguration or provider mismatch could break Ask until rollback, though legacy parsing and documented rollback paths reduce blast radius.
> 
> **Overview**
> Migrates the Worker’s **AI Search upstream** from the legacy AutoRAG-style contract to Cloudflare **AI Search Chat Completions**, while keeping the public **`/api/ai-search`** JSON/SSE shape the same for clients.
> 
> The route now builds **`messages`** requests and uses **`AI_SEARCH_API_TOKEN` only** (no legacy `search-api` fallback). New **`upstream`** helpers parse chat **`choices`**, **`chunks`**, and errors, with **legacy response shapes** still supported for rollback. **Source parsing** is extended for chunk-style metadata (`item`, `text`, paths). Conversation **history** is limited to **`user` / `assistant`** roles.
> 
> Adds a **six-hour cron** that POSTs a timestamped canary to production **`/api/ai-search`**, records **ok/error, latency, and message length** in Analytics Engine (no prompt/answer text), and reports failures to **Sentry**. **`/__scheduled`** is **404 in production**; **`wrangler.toml`** updates the endpoint, required secrets, and cron trigger. Docs and ops runbooks cover **rollback** to AutoRAG and **disabling the canary**; **Wrangler** is bumped to **4.118.0** with focused Vitest coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040357c727976fb38b939ba5711d5a733e4d1cb7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->