### PR TITLE
fix(security): harden PR labeler and session IDs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,13 +12,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout labeler config from PR head
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          sparse-checkout: .github/labeler.yml
-          sparse-checkout-cone-mode: false
-
       - name: Apply labels based on changed files
         uses: actions/labeler@v7
         with:

--- a/src/lib/chat/conversation-ws.ts
+++ b/src/lib/chat/conversation-ws.ts
@@ -195,7 +195,7 @@ export class ConversationWebSocket {
    * Generate unique session ID
    */
   private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+    return `session_${globalThis.crypto.randomUUID()}`;
   }
 }
 
@@ -276,6 +276,6 @@ export class ConversationHTTP {
   }
 
   private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+    return `session_${globalThis.crypto.randomUUID()}`;
   }
 }


### PR DESCRIPTION
## What changed
- Remove pull-request-head checkout from the privileged `pull_request_target` labeler workflow.
- Generate client conversation session IDs with `crypto.randomUUID()`.

## Why
Remediates CodeQL findings for untrusted checkout and insecure randomness.

## Impact
No product API changes. The labeler continues to load `.github/labeler.yml` from the repository API when it is not checked out.

## Testing
- Focused Vitest tests: 7 passed
- `pnpm run typecheck`: 0 errors, warnings, or hints
- Pre-push typecheck and lint passed; lint retains one pre-existing warning
- Prettier and diff checks passed

## Not included
Unrelated duplicate ` 2` files remain unmodified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Security-focused hardening with no product API changes; labeler behavior should remain equivalent via the labeler action’s config fetch.
> 
> **Overview**
> Addresses CodeQL findings by removing **untrusted checkout** from the `pull_request_target` PR labeler and switching conversation **session ID** generation to cryptographically secure randomness.
> 
> The labeler workflow no longer checks out the PR head (sparse `.github/labeler.yml`); it relies on `actions/labeler@v7` loading `.github/labeler.yml` from the repository via the API with the existing token permissions.
> 
> In `conversation-ws.ts`, both `ConversationWebSocket` and `ConversationHTTP` now build session IDs as `session_${globalThis.crypto.randomUUID()}` instead of `Date.now()` plus `Math.random()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f4826a19085d3dabbb6edb5ba52b84ea2259c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->