### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/act-essential.yml
+++ b/.github/workflows/act-essential.yml
@@ -5,6 +5,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   essential-test:
     name: Essential Tests (Act)

--- a/.github/workflows/act-local.yml
+++ b/.github/workflows/act-local.yml
@@ -7,6 +7,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   local-test:
     name: Local E2E Test Debug

--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, edited, reopened, ready_for_review]
 
+permissions:
+  pull-requests: read
+
 jobs:
   guard:
     name: Enforce Branch Flow

--- a/.github/workflows/contrast-nightly.yml
+++ b/.github/workflows/contrast-nightly.yml
@@ -5,6 +5,10 @@ on:
     - cron: '15 3 * * 1'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   contrast:
     runs-on: ubuntu-latest

--- a/.github/workflows/reliability-weekly.yml
+++ b/.github/workflows/reliability-weekly.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * 1' # Mondays 06:00 UTC
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   essential-reliability:
     name: Essential + device matrix


### PR DESCRIPTION
## What changed
- Add explicit least-privilege permissions to the contrast, reliability, branch-flow, and local test workflows.
- Grant `issues: write` only to the contrast workflow because it creates issues; all other workflows receive only the read scope they require.

## Why
Remediates six CodeQL missing-workflow-permissions alerts and prevents repository-level default token permissions from widening these jobs.

## Impact
No application runtime changes. Scheduled contrast issue creation remains authorized; checkout and PR metadata reads remain functional.

## Testing
- `pnpm run typecheck`: 0 errors, warnings, or hints
- Pre-push lint: 0 errors, 1 pre-existing warning
- `git diff --check` passed
- Actionlint reports only existing ShellCheck advisories in `contrast-nightly.yml`

## Not included
Application sanitizer/ReDoS findings and unrelated untracked files remain separate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only YAML changes that narrow token scope; contrast issue creation keeps the only elevated `issues: write` grant.
> 
> **Overview**
> Adds **explicit least-privilege `permissions`** to five GitHub Actions workflows so jobs no longer inherit broad default `GITHUB_TOKEN` scopes.
> 
> `act-essential`, `act-local`, and `reliability-weekly` get **`contents: read`** for checkout and test runs. **`branch-flow-guard`** gets **`pull-requests: read`** for PR metadata in `github-script` (plus a trailing newline fix at EOF). **`contrast-nightly`** gets **`contents: read`** and **`issues: write`** so scheduled contrast alerts can still open issues via `create-issue-from-file`.
> 
> No job steps or application code change—only workflow-level token scoping for CodeQL **missing-workflow-permissions** remediation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64005624054369095a9baf327dc81be7d00ec72e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->