### PR TITLE
fix(security): avoid regex backtracking in markdown cleanup

### DIFF
--- a/src/lib/string-utils.ts
+++ b/src/lib/string-utils.ts
@@ -56,6 +56,32 @@ export function cleanSnippet(snippet: string): string {
     .trim();
 }
 
+function stripFencedCodeBlocks(value: string): string {
+  const fence = '```';
+  let cursor = 0;
+  let result = '';
+
+  while (cursor < value.length) {
+    const openingStart = value.indexOf(fence, cursor);
+    if (openingStart === -1) return result + value.slice(cursor);
+
+    result += value.slice(cursor, openingStart);
+    const contentStart = openingStart + fence.length;
+    const closingStart = value.indexOf(fence, contentStart);
+    if (closingStart === -1) return result + value.slice(openingStart);
+
+    const languageLineEnd = value.indexOf('\n', contentStart);
+    const bodyStart =
+      languageLineEnd !== -1 && languageLineEnd < closingStart
+        ? languageLineEnd + 1
+        : contentStart;
+    result += value.slice(bodyStart, closingStart);
+    cursor = closingStart + fence.length;
+  }
+
+  return result;
+}
+
 /**
  * Clean assistant response text for plain-text chat bubbles.
  * Models often emit markdown (**bold**, headers) that looks broken when not rendered.
@@ -73,7 +99,7 @@ export function cleanAssistantResponse(content: string): string {
   }
 
   // Fenced code blocks → inner text
-  cleaned = cleaned.replace(/```[\w-]*\n?([\s\S]*?)```/g, '$1');
+  cleaned = stripFencedCodeBlocks(cleaned);
 
   // Headings: "## Title" → "Title"
   cleaned = cleaned.replace(/^#{1,6}\s+/gm, '');

--- a/tests/vitest/string-utils.test.ts
+++ b/tests/vitest/string-utils.test.ts
@@ -20,4 +20,13 @@ describe('cleanAssistantResponse', () => {
       cleanAssistantResponse('See [Microsoft Fabric](/projects/microsoft-fabric/) and `Power BI`.')
     ).toBe('See Microsoft Fabric and Power BI.');
   });
+
+  it('strips fenced code blocks without changing their inner text', () => {
+    expect(cleanAssistantResponse('```ts\nconst value = 1;\n```')).toBe('const value = 1;');
+  });
+
+  it('leaves an unterminated fenced block unchanged', () => {
+    const input = '```ts\nconst value = 1;';
+    expect(cleanAssistantResponse(input)).toBe(input);
+  });
 });


### PR DESCRIPTION
## What changed
- Replace the lazy fenced-code regex with a linear `indexOf` scanner.
- Preserve fenced-block content and leave unterminated blocks unchanged.
- Add regression tests for both behaviors.

## Why
Remediates the CodeQL polynomial ReDoS finding in `cleanAssistantResponse`.

## Impact
Assistant markdown cleanup behavior is preserved for normal fenced blocks; unclosed fences are handled deterministically without regex backtracking.

## Testing
- Focused Vitest: 5 passed
- `pnpm run typecheck`: 0 errors, warnings, or hints
- Pre-push lint: 0 errors, 1 pre-existing warning
- `git diff --check` passed

## Not included
Unrelated sanitizer findings and duplicate untracked files remain separate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized string-sanitization change with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Remediates a CodeQL ReDoS finding** in `cleanAssistantResponse` by replacing the lazy-regex fenced-code stripper with a linear `stripFencedCodeBlocks` helper that walks the string with `indexOf`.
> 
> For normal ` ``` ` blocks, behavior stays the same: optional language line is skipped and only the inner code is kept for plain-text chat bubbles (`ChatMessageBubble`). **Unclosed fences** are now handled explicitly—the remainder of the string from the opening fence is left as-is instead of going through regex backtracking.
> 
> Vitest adds coverage for closed blocks and unterminated fences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70ef7370b00ce42005c606ffca5878d48e1e7d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->