### PR TITLE
fix(security): close sanitizer CodeQL findings

### DIFF
--- a/src/features/contact/form/FormHelpers.ts
+++ b/src/features/contact/form/FormHelpers.ts
@@ -50,7 +50,7 @@ export function getFieldLabel(field: HTMLElement, fallback: string): string {
   const labelArray = Array.from(labels);
   if (labelArray.length > 0) {
     const raw = labelArray[0]?.textContent ?? '';
-    return raw.replace('*', '').trim() || fallback;
+    return raw.replaceAll('*', '').trim() || fallback;
   }
   const ariaLabel = field.getAttribute('aria-label');
   if (ariaLabel) return ariaLabel.trim();

--- a/src/utils/links/deadLinkCore.js
+++ b/src/utils/links/deadLinkCore.js
@@ -9,6 +9,68 @@ import path from 'path';
 
 const SKIP_PROTOCOLS = ['mailto:', 'tel:', 'data:'];
 
+function findTagStart(lowerHtml, tagName, fromIndex) {
+  const marker = `<${tagName}`;
+  let start = lowerHtml.indexOf(marker, fromIndex);
+  while (start !== -1) {
+    const boundary = lowerHtml[start + marker.length];
+    if (
+      boundary === undefined ||
+      boundary === '>' ||
+      boundary === '/' ||
+      boundary === ' ' ||
+      boundary === '\t' ||
+      boundary === '\r' ||
+      boundary === '\n'
+    ) {
+      return start;
+    }
+    start = lowerHtml.indexOf(marker, start + 1);
+  }
+  return -1;
+}
+
+function stripNonContentRegions(html) {
+  const lowerHtml = html.toLowerCase();
+  let cursor = 0;
+  let output = '';
+
+  while (cursor < html.length) {
+    const candidates = [
+      { start: lowerHtml.indexOf('<!--', cursor), type: 'comment' },
+      { start: findTagStart(lowerHtml, 'script', cursor), type: 'script' },
+      { start: findTagStart(lowerHtml, 'style', cursor), type: 'style' },
+    ].filter(({ start }) => start !== -1);
+
+    if (candidates.length === 0) break;
+
+    const next = candidates.reduce((earliest, candidate) =>
+      candidate.start < earliest.start ? candidate : earliest
+    );
+    output += html.slice(cursor, next.start);
+
+    if (next.type === 'comment') {
+      const end = lowerHtml.indexOf('-->', next.start + 4);
+      if (end === -1) return output + html.slice(next.start);
+      cursor = end + 3;
+      continue;
+    }
+
+    const tagName = next.type;
+    const openingEnd = lowerHtml.indexOf('>', next.start + tagName.length + 1);
+    if (openingEnd === -1) return output + html.slice(next.start);
+
+    const closingStart = lowerHtml.indexOf(`</${tagName}`, openingEnd + 1);
+    if (closingStart === -1) return output + html.slice(next.start);
+
+    const closingEnd = lowerHtml.indexOf('>', closingStart + tagName.length + 2);
+    if (closingEnd === -1) return output + html.slice(next.start);
+    cursor = closingEnd + 1;
+  }
+
+  return output + html.slice(cursor);
+}
+
 /**
  * Extract URLs (internal + optionally external) from an HTML string.
  * Returns array of objects: { raw, isExternal }
@@ -16,15 +78,7 @@ const SKIP_PROTOCOLS = ['mailto:', 'tel:', 'data:'];
 export function extractLinks(html, { includeExternal = false } = {}) {
   const links = new Map();
   // Strip comments / script / style so JS template strings like href="${t}" are not treated as links.
-  let cleaned = html;
-  let previous;
-  do {
-    previous = cleaned;
-    cleaned = cleaned
-      .replace(/<!--([\s\S]*?)-->/g, '')
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
-  } while (cleaned !== previous);
+  const cleaned = stripNonContentRegions(html);
   const attrRe = /(href|src)=["']([^"']+)["']/gi;
   let m;
   while ((m = attrRe.exec(cleaned))) {

--- a/tests/vitest/contact/formHelpers.test.ts
+++ b/tests/vitest/contact/formHelpers.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getFieldLabel } from '../../../src/features/contact/form/FormHelpers';
+
+describe('getFieldLabel', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('removes every required marker from the associated label', () => {
+    const label = document.createElement('label');
+    const field = document.createElement('input');
+    label.htmlFor = 'project';
+    label.textContent = '* Project * brief *';
+    field.id = 'project';
+    document.body.append(label, field);
+
+    expect(getFieldLabel(field, 'Fallback')).toBe('Project  brief');
+  });
+});

--- a/tests/vitest/deadlinks/deadLinkCore.test.ts
+++ b/tests/vitest/deadlinks/deadLinkCore.test.ts
@@ -66,6 +66,18 @@ describe('deadLinkCore', () => {
     expect(urls).not.toContain('/${href}');
   });
 
+  it('ignores links inside comments and case-insensitive script/style blocks', () => {
+    const withNonContent = `
+<html><body>
+  <!-- <a href="/commented-out">Comment</a> -->
+  <a href="/visible">Visible</a>
+  <SCRIPT data-test="true">const href = "/script-only";</SCRIPT >
+  <style>.link::after { content: "href='/style-only'"; }</style>
+</body></html>`;
+    const urls = extractLinks(withNonContent, { includeExternal: false }).map((l) => l.raw);
+    expect(urls).toEqual(['/visible']);
+  });
+
   it('buildLinkTasks normalizes relative paths', () => {
     setup();
     const tasks = buildLinkTasks([pageFile], distDir, { includeExternal: false });


### PR DESCRIPTION
## What changed
- Replace the contact-label single-marker cleanup with complete marker removal.
- Replace regex-based comment/script/style stripping in the dead-link checker with deterministic index scanning.
- Add regression coverage for contact labels and non-content HTML regions.

## Why
- Close the remaining sanitizer-related CodeQL findings without weakening output escaping or link-check behavior.

## Impact
- Build-time dead-link extraction remains behaviorally equivalent for valid HTML and preserves malformed regions for diagnostics.
- No runtime deployment or data migration.

## Testing
- Focused Vitest: 7 passed.
- `pnpm run typecheck`: 0 errors, 0 warnings, 0 hints.
- `pnpm run lint`: 0 errors; one pre-existing warning in `functions/shared/route-context.ts:10`.
- Pre-push checks passed.

## Screenshots
- Not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time and form-label cleanup only; behavior is tightened with tests and no auth, data, or deployment changes.
> 
> **Overview**
> Addresses CodeQL sanitizer findings with two targeted behavior fixes plus regression tests.
> 
> **Contact form labels:** `getFieldLabel` now uses `replaceAll('*', '')` so every required-marker asterisk is stripped from associated label text, not only the first match.
> 
> **Dead-link HTML preprocessing:** `extractLinks` no longer uses repeated regex passes to drop comments, `script`, and `style` blocks. It uses deterministic index scanning (`stripNonContentRegions` / `findTagStart`) so non-content regions are skipped without regex-based removal patterns CodeQL flagged, while keeping equivalent link extraction for visible markup.
> 
> Vitest coverage was added for multi-asterisk labels and for links inside comments and case-variant script/style blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2ebad0e3f19bf5217969484da8d78a25235803. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->