### PR TITLE
fix(seo): decode XML entities in one pass

### DIFF
--- a/scripts/quality/check-seo.mjs
+++ b/scripts/quality/check-seo.mjs
@@ -14,12 +14,14 @@ function walk(directory) {
 }
 
 function decodeEntities(value) {
-  return value
-    .replace(/&amp;/g, '&')
-    .replace(/&#39;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
+  const entities = {
+    '&amp;': '&',
+    '&#39;': "'",
+    '&quot;': '"',
+    '&lt;': '<',
+    '&gt;': '>',
+  };
+  return value.replace(/&amp;|&#39;|&quot;|&lt;|&gt;/g, (entity) => entities[entity]);
 }
 
 function tags(html, name) {

--- a/scripts/seo/indexnow-submit.mjs
+++ b/scripts/seo/indexnow-submit.mjs
@@ -104,12 +104,14 @@ export function validateUrls(urls) {
 }
 
 function decodeXmlEntities(value) {
-  return value
-    .replaceAll('&amp;', '&')
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
-    .replaceAll('&quot;', '"')
-    .replaceAll('&apos;', "'");
+  const entities = {
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&apos;': "'",
+  };
+  return value.replace(/&amp;|&lt;|&gt;|&quot;|&apos;/g, (entity) => entities[entity]);
 }
 
 async function urlsFromSitemap(sitemapValue) {


### PR DESCRIPTION
## What changed

- Replaced chained XML/HTML entity replacements with single-pass lookup decoders in the SEO contract and IndexNow sitemap parser.
- Prevents double-decoding inputs such as `&amp;lt;`.

## Validation

- `pnpm quality:indexnow`: passed.
- `pnpm quality:seo`: 25 built pages and 18 sitemap URLs passed.
- `pnpm typecheck`: 334 files, 0 errors/warnings/hints.
- `pnpm lint`: passed.
- GitHub CodeQL previously identified both affected helpers as high-severity double-decoding findings.

This follows the documented `feature/* -> development` flow and is required before the production release PR can merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to offline quality/IndexNow scripts with no production request path impact.
> 
> **Overview**
> **Entity decoding** in the SEO quality checker and IndexNow sitemap parser no longer runs as a chain of separate `.replace` / `.replaceAll` calls. Both `decodeEntities` (built HTML titles) and `decodeXmlEntities` (`<loc>` values) now use one regex pass with a lookup map.
> 
> That closes **double-decoding** cases such as `&amp;lt;`, where an earlier `&amp;` → `&` step could turn a safely encoded sequence into a real `<` after a later `&lt;` rule ran.
> 
> Behavior for normal single-encoded entities is unchanged; this is a correctness fix aligned with prior CodeQL findings on these helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669947ad020c382ea603915764043724ada1f3b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->