### PR TITLE
fix(release): promote CodeQL entity-decoding repair to testing

### DIFF
--- a/scripts/quality/check-seo.mjs
+++ b/scripts/quality/check-seo.mjs
@@ -14,12 +14,14 @@ function walk(directory) {
 }
 
 function decodeEntities(value) {
-  return value
-    .replace(/&amp;/g, '&')
-    .replace(/&#39;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
+  const entities = {
+    '&amp;': '&',
+    '&#39;': "'",
+    '&quot;': '"',
+    '&lt;': '<',
+    '&gt;': '>',
+  };
+  return value.replace(/&amp;|&#39;|&quot;|&lt;|&gt;/g, (entity) => entities[entity]);
 }
 
 function tags(html, name) {

--- a/scripts/seo/indexnow-submit.mjs
+++ b/scripts/seo/indexnow-submit.mjs
@@ -104,12 +104,14 @@ export function validateUrls(urls) {
 }
 
 function decodeXmlEntities(value) {
-  return value
-    .replaceAll('&amp;', '&')
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
-    .replaceAll('&quot;', '"')
-    .replaceAll('&apos;', "'");
+  const entities = {
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&apos;': "'",
+  };
+  return value.replace(/&amp;|&lt;|&gt;|&quot;|&apos;/g, (entity) => entities[entity]);
 }
 
 async function urlsFromSitemap(sitemapValue) {


### PR DESCRIPTION
Promotes the CodeQL repair from merged PR #507 into `testing` so release PR #506 contains the corrected entity decoders.

Evidence:
- PR #507 passed CodeQL replacement checks, security/dependency scan, Essential Chromium E2E, Required Checks Gate, and Workers Build.
- The repair changes only the SEO contract and IndexNow XML entity decoders.
- This follows the documented `development -> testing` promotion flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to internal decoding helpers in build/SEO tooling; logic is equivalent to the previous implementation.
> 
> **Overview**
> Refactors HTML/XML entity decoding in the SEO quality script and IndexNow sitemap parser so CodeQL stops flagging chained `replace`/`replaceAll` patterns, without changing which entities are decoded or how callers use the helpers.
> 
> In **`check-seo.mjs`**, `decodeEntities` now uses a small entity map and one regex-driven `replace` instead of five sequential `.replace` calls (still used when normalizing `<title>` text for contract checks). In **`indexnow-submit.mjs`**, `decodeXmlEntities` follows the same pattern for sitemap `<loc>` values (including `&apos;`), replacing multiple `.replaceAll` calls.
> 
> This is a promotion of the repair from PR #507 into the release branch; behavior for SEO validation and IndexNow URL extraction should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52a0dd97601a8621fdd4b51799de44b3bb61227c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->