### PR TITLE
ci(seo): run production smoke on automation NUC

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - nuc
+    - seo

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -90,7 +90,20 @@ jobs:
           print(f"✅ Cloudflare reports the active deployment for {os.environ['EXPECTED_COMMIT']}")
           PY
 
+  seo-monitor:
+    name: Verify deployed SEO and redirect contract (NUC)
+    needs: deploy
+    runs-on: [self-hosted, linux, x64, nuc, seo]
+    timeout-minutes: 15
+    env:
+      # The automation NUC intentionally exposes the pinned Node runtime only
+      # to trusted repository workflows; this smoke does not receive secrets.
+      PATH: /home/github-runner/.local/node-v24.18.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Verify deployed SEO and redirect contract
         env:
           EDGE_EXPECTED_COMMIT: ${{ github.sha }}
-        run: pnpm monitor:seo
+        run: bash scripts/monitor/seo-edge-smoke.sh


### PR DESCRIPTION
## What changed
- Keep deployment, Vectorize refresh, and provenance on the hosted deployment job.
- Run only the public post-deploy SEO/redirect smoke on the repo-scoped automation NUC.
- Register the custom `nuc` and `seo` labels with actionlint.

## Why
Cloudflare Bot Fight Mode blocks GitHub-hosted public probes with HTTP 403. The trusted local NUC already provides the same controlled execution pattern used by whisperx-gui and preserves Bot Fight Mode.

## Impact
- No deployment secrets are exposed to the NUC job.
- The NUC runner is repo-scoped and uses labels `self-hosted, linux, x64, nuc, seo`.
- Kill switch: disable the `seo-monitor` job/workflow or stop its runner service; production traffic controls are unchanged.

## Testing
- `actionlint .github/workflows/deploy-worker.yml`
- `git diff --check`
- Production local smoke passes at `cc8cf712e2e19394b87d57d6a5c6b596e75ca9e6`
- Repo runner registered online as `automation-nuc-blakeoxford`

## Rollback
Revert this workflow change to restore the prior hosted smoke path; do not disable Bot Fight Mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; production deploy and secrets stay on the hosted job, and the NUC step only runs the existing public smoke script.
> 
> **Overview**
> **Moves the post-deploy SEO and redirect contract check** out of the hosted `deploy` job into a new `seo-monitor` job that runs after deploy on a self-hosted runner labeled `nuc` and `seo`.
> 
> The smoke still sets `EDGE_EXPECTED_COMMIT` to the deploy SHA and runs `scripts/monitor/seo-edge-smoke.sh` (same script as `pnpm monitor:seo`), with a pinned Node `PATH` and **no deployment secrets** on the NUC job.
> 
> Adds **`.github/actionlint.yaml`** so actionlint recognizes the custom runner labels `nuc` and `seo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d23eb2f6d7986df7a3eefcc0adf355b47594bb6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->