### PR TITLE
release: promote development to testing

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - nuc
+    - seo

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -90,7 +90,20 @@ jobs:
           print(f"✅ Cloudflare reports the active deployment for {os.environ['EXPECTED_COMMIT']}")
           PY
 
+  seo-monitor:
+    name: Verify deployed SEO and redirect contract (NUC)
+    needs: deploy
+    runs-on: [self-hosted, linux, x64, nuc, seo]
+    timeout-minutes: 15
+    env:
+      # The automation NUC intentionally exposes the pinned Node runtime only
+      # to trusted repository workflows; this smoke does not receive secrets.
+      PATH: /home/github-runner/.local/node-v24.18.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Verify deployed SEO and redirect contract
         env:
           EDGE_EXPECTED_COMMIT: ${{ github.sha }}
-        run: pnpm monitor:seo
+        run: bash scripts/monitor/seo-edge-smoke.sh


### PR DESCRIPTION
## What changed
Promote the merged NUC-backed SEO monitor workflow from development to testing.

## Verification
- Feature PR #509 merged to development as `99140b18a915c92ac3a5addb11f6b3bb2d8294b9`.
- NUC runner `automation-nuc-blakeoxford` is online with labels `self-hosted, Linux, X64, nuc, seo`.
- PR #509 checks passed, including Essential E2E and Required Checks Gate.

## Promotion control
This is the controlled development -> testing promotion; production deployment remains a separate testing -> main promotion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and actionlint config; post-deploy smoke against the public edge with no new secrets in the monitor job.
> 
> **Overview**
> **Deploy Worker** gains a **`seo-monitor`** job that runs after **`deploy`** on a self-hosted runner tagged **`nuc`** and **`seo`**, with a pinned Node **`PATH`** on the automation NUC and no workflow secrets for that smoke.
> 
> The SEO check step now runs **`bash scripts/monitor/seo-edge-smoke.sh`** (with **`EDGE_EXPECTED_COMMIT`** set to the deploy SHA) instead of **`pnpm monitor:seo`**.
> 
> **`.github/actionlint.yaml`** is added so actionlint recognizes the **`nuc`** and **`seo`** self-hosted runner labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99140b18a915c92ac3a5addb11f6b3bb2d8294b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->