### PR TITLE
release: promote testing to main

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - nuc
+    - seo

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -90,7 +90,20 @@ jobs:
           print(f"✅ Cloudflare reports the active deployment for {os.environ['EXPECTED_COMMIT']}")
           PY
 
+  seo-monitor:
+    name: Verify deployed SEO and redirect contract (NUC)
+    needs: deploy
+    runs-on: [self-hosted, linux, x64, nuc, seo]
+    timeout-minutes: 15
+    env:
+      # The automation NUC intentionally exposes the pinned Node runtime only
+      # to trusted repository workflows; this smoke does not receive secrets.
+      PATH: /home/github-runner/.local/node-v24.18.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Verify deployed SEO and redirect contract
         env:
           EDGE_EXPECTED_COMMIT: ${{ github.sha }}
-        run: pnpm monitor:seo
+        run: bash scripts/monitor/seo-edge-smoke.sh


### PR DESCRIPTION
## What changed
Promote the NUC-backed production SEO smoke workflow to `main`.

## Verification
- Feature PR #509 merged to development as `99140b18a915c92ac3a5addb11f6b3bb2d8294b9`.
- Promotion PR #510 merged to testing as `f3e7e09a69c0c91ada4403278644ebcc91baa543`.
- Both PRs passed the required checks and Chromium E2E suites.
- Repo runner `automation-nuc-blakeoxford` is online with labels `self-hosted, Linux, X64, nuc, seo`.

## Production control
After merge, run the controlled deployment workflow. Deployment secrets remain on the hosted deploy job; only public SEO smoke runs on the NUC. Bot Fight Mode remains enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes: new smoke job on a trusted self-hosted runner with no secrets; deploy logic unchanged.
> 
> **Overview**
> Adds a **post-deploy `seo-monitor` job** to the manual deploy workflow that runs after `deploy` on the self-hosted NUC (`nuc`, `seo` labels), with a pinned Node `PATH` and no deployment secrets.
> 
> The SEO check still uses `EDGE_EXPECTED_COMMIT` but invokes **`scripts/monitor/seo-edge-smoke.sh` directly** instead of `pnpm monitor:seo` (same underlying script).
> 
> **`.github/actionlint.yaml`** is added so actionlint accepts the custom self-hosted runner labels `nuc` and `seo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e7e09a69c0c91ada4403278644ebcc91baa543. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated post-deployment checks for SEO behavior and redirects.
  * Deployments now receive additional verification after completion to help detect routing or search-visibility issues.
  * Updated deployment validation to run reliably on the designated verification environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->