### PR TITLE
chore(release): promote CI safety fix to testing

### DIFF
--- a/.github/workflows/ci-comprehensive.yml
+++ b/.github/workflows/ci-comprehensive.yml
@@ -267,22 +267,21 @@ jobs:
 
       - name: Run advanced optimizations
         run: pnpm optimize:images
+        env:
+          OPTIMIZATION_OUTPUT_DIR: ${{ runner.temp }}/blakeoxford-optimized-images
 
       - name: Snapshot quality baseline (main only)
         run: pnpm quality:snapshot || true
         if: github.ref == 'refs/heads/main'
 
-      - name: Commit quality snapshot index (if changed)
+      - name: Report quality snapshot changes
         if: github.ref == 'refs/heads/main'
         run: |
           if git diff --quiet quality-snapshots/INDEX.md; then
             echo "No snapshot index changes"
           else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add quality-snapshots/INDEX.md
-            git commit -m "chore(ci): update quality snapshot index [skip ci]" || true
-            git push || echo "Snapshot push race condition; safe to ignore"
+            echo "::notice::Quality snapshot changed in the isolated CI workspace; persistence requires a reviewed pull request."
+            git diff --stat -- quality-snapshots/INDEX.md
           fi
 
       - name: Validate Cloudflare Functions
@@ -296,10 +295,24 @@ jobs:
             echo "⚠️ Warning: Some edge functions may be missing"
           fi
 
-      - name: Commit optimized assets
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: '🚀 Automated optimizations [skip ci]'
-          file_pattern: 'public/assets/images/** src/assets/**'
+      - name: Write optimization validation report
+        run: |
+          report_dir="${RUNNER_TEMP}/optimization-report"
+          output_dir="${OPTIMIZATION_OUTPUT_DIR}"
+          mkdir -p "$report_dir"
+          test -d "$output_dir"
+          find "$output_dir" -type f -print0 | sort -z | xargs -0 shasum -a 256 > "$report_dir/files.sha256"
+          find "$output_dir" -type f | wc -l > "$report_dir/file-count.txt"
+          du -sh "$output_dir" > "$report_dir/size.txt"
+          printf 'Optimization output is validation-only. Generated assets are not pushed by CI.\n' > "$report_dir/README.txt"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPTIMIZATION_OUTPUT_DIR: ${{ runner.temp }}/blakeoxford-optimized-images
+
+      - name: Upload optimization validation report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: optimized-assets-validation-${{ github.sha }}
+          path: ${{ runner.temp }}/optimization-report
+          retention-days: 30
+          if-no-files-found: error

--- a/docs/operations/seo-review.md
+++ b/docs/operations/seo-review.md
@@ -61,39 +61,42 @@ implementation does not send or retain the referrer URL, search query, form cont
 address. Use this event as the aggregate organic-contact conversion measure after the analytics
 property is verified.
 
-## Latest recorded measurement state: 2026-08-09
+## Latest recorded measurement state: 2026-08-10
 
-Reviewed 2026-08-09 against production commit `cc228629` and the authenticated personal Search
-Console property:
+Reviewed 2026-08-10 against production commit `1834ffb56f0bbfe15d9d43b449a4adc8b460d107`,
+the authenticated personal Search Console property, and the Cloudflare Zaraz control plane:
 
-- Technical live gates are green: `pnpm monitor:seo` passes all redirect, robots, sitemap,
-  route-wide HTML parity, metadata, and provenance checks across 18 canonical sitemap URLs.
+- Technical live gates are green in [workflow 31346176288](https://github.com/blakeox/blakeoxford.com/actions/runs/31346176288): hosted deployment, provenance, and the repo-scoped NUC smoke pass all redirect, robots, sitemap, route-wide HTML parity, metadata, and provenance checks across 18 canonical sitemap URLs.
 - Google Search Console personal-site property is accessible. The canonical sitemap was submitted,
-  last read on the review date, with 18 discovered pages and 0 videos.
+  with 18 discovered pages and 0 videos in the recorded sitemap receipt.
 - Initial Search Console overview baseline: 9 total web-search clicks, 16 indexed pages,
-  13 not-indexed pages, 10 HTTPS URLs, 0 non-HTTPS URLs, and no Core Web Vitals data yet.
-- Search Console Performance (Web, 3 months, 2026-05-08 through 2026-08-07; updated four hours
-  before review): 737 impressions, 9 clicks, 1.2% average CTR, and 16.7 average position. The
+  14 not-indexed pages, 10 HTTPS URLs, 0 non-HTTPS URLs, and no Core Web Vitals data yet.
+- Search Console Performance (Web, 3 months, 2026-05-08 through 2026-08-07; refreshed 2026-08-10):
+  737 impressions, 9 clicks, 1.2% average CTR, and 16.7 average position. The
   query and landing-page tables were reviewed without copying raw search queries or personal data
   into this repository.
-- Search Console Page indexing (last updated 2026-08-04) reports 13 not-indexed pages across five
+- Search Console Page indexing (last updated 2026-08-06) reports 14 not-indexed pages across five
   reasons: two expected canonical redirects, two expected query-filter canonical alternates, one
-  404, one other 4xx, and seven crawled-but-currently-not-indexed URLs. The historical query
-  surfaces are tracked in #500; the 404/4xx examples remain an external coverage follow-up.
+  404, one other 4xx, and eight crawled-but-currently-not-indexed URLs. The historical query
+  surfaces remain under provider validation in #500; the 404/4xx examples remain an external
+  coverage follow-up.
 - Search Console Unparsable structured data (last updated 2026-08-07) reports two historical
   parsing errors affecting `/projects/ferment-app` and `/blog/building-my-own-local-llm-stack/`.
-  Current production JSON-LD parses successfully for both URLs; Search Console validation remains
-  pending under #501.
-- Bing Webmaster Tools personal property is selected and the canonical sitemap is submitted;
-  status is `Processing` with 0 errors, 0 warnings, and 1 known sitemap. Bing has not yet
-  crawled or discovered URLs.
+  Current production JSON-LD parses successfully for both URLs; provider validation remains
+  `Started` under #501.
+- Bing's connected Microsoft property set currently does not expose `blakeoxford.com`; the earlier
+  personal-property sitemap receipt remains `Processing` with 0 errors, 0 warnings, and 1 known
+  sitemap. No new Bing crawl or performance data is claimed.
+- Cloudflare Zaraz has the GA4 tool enabled with privacy settings that hide IP addresses, user
+  agents, query parameters, and external referrers; the latest configuration publish was
+  2026-08-09. This proves collection is configured, not that a qualified organic lead occurred.
 - Qualified organic contact counts and Bing performance data are still pending. The Search Console
-  aggregate performance baseline is now recorded, but do not treat it as a complete conversion or
+  aggregate performance baseline is recorded, but do not treat it as a complete conversion or
   cross-engine baseline until the remaining fields are captured.
 
-The current branch also adds an edge-level `X-Robots-Tag: noindex, nofollow` response for
-query-bearing HTML requests, addressing the legacy `?filter=` crawl surface tracked in #500. This
-control is not a production receipt until deployed and live-verified.
+The production release also enforces an edge-level `X-Robots-Tag: noindex, nofollow` response for
+query-bearing HTML requests, addressing the legacy `?filter=` crawl surface tracked in #500. The
+control is deployed and live-verified by the NUC smoke; provider exclusion validation remains open.
 
 Facebook validation is intentionally out of scope. X/Twitter card validation remains a separate
 provider-authenticated check.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   minimatch: 10.2.3
   brace-expansion: '>=5.0.8'
   rollup: 4.59.0
@@ -4739,8 +4739,8 @@ packages:
   mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12167,7 +12167,7 @@ snapshots:
 
   mute-stream@0.0.7: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -12524,7 +12524,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ onlyBuiltDependencies:
   - workerd
 
 overrides:
-  nanoid: '3.3.17'
+  nanoid: '3.3.18'
   minimatch: '10.2.3'
   brace-expansion: '>=5.0.8'
   rollup: '4.59.0'

--- a/scripts/optimization/optimize-images-advanced.js
+++ b/scripts/optimization/optimize-images-advanced.js
@@ -13,15 +13,19 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const INPUT_DIR = path.join(__dirname, '../../public/assets/images');
-const OUTPUT_DIR = path.join(__dirname, '../../public/assets/images/optimized');
+const INPUT_DIR = process.env.OPTIMIZATION_INPUT_DIR
+  ? path.resolve(process.env.OPTIMIZATION_INPUT_DIR)
+  : path.join(__dirname, '../../public/assets/images');
+const OUTPUT_DIR = process.env.OPTIMIZATION_OUTPUT_DIR
+  ? path.resolve(process.env.OPTIMIZATION_OUTPUT_DIR)
+  : path.join(__dirname, '../../public/assets/images/optimized');
 
 // Image optimization configurations
 const FORMATS = {
   avif: { quality: 80, effort: 4 },
   webp: { quality: 85, effort: 4 },
   jpeg: { quality: 85, progressive: true },
-  png: { compressionLevel: 9 }
+  png: { compressionLevel: 9 },
 };
 
 const RESPONSIVE_SIZES = [320, 640, 768, 1024, 1280, 1536, 1920];
@@ -100,7 +104,8 @@ async function optimizeImage(inputPath, filename) {
       // Responsive sizes (only if image is large enough)
       for (const width of responsiveWidths(originalWidth)) {
         const responsiveOutputPath = path.join(formatDir, `${nameWithoutExt}@${width}w.${format}`);
-        await image.clone()
+        await image
+          .clone()
           .resize(width, null, { withoutEnlargement: true })
           // eslint-disable-next-line no-unexpected-multiline
           [format](FORMATS[format])
@@ -114,14 +119,13 @@ async function optimizeImage(inputPath, filename) {
       formats: Object.keys(FORMATS),
       sizes: responsiveWidths(originalWidth),
       width: originalWidth,
-      height: metadata.height
+      height: metadata.height,
     };
 
     const manifestPath = path.join(OUTPUT_DIR, `${nameWithoutExt}.json`);
     await fs.writeFile(manifestPath, JSON.stringify(srcsetData, null, 2));
 
     console.log(`   ✅ Generated ${Object.keys(FORMATS).length} formats with responsive variants`);
-
   } catch (error) {
     console.error(`   ❌ Error processing ${filename}:`, error.message);
   }
@@ -134,9 +138,8 @@ async function generateOptimizedImages() {
 
   try {
     const files = await fs.readdir(INPUT_DIR);
-    const imageFiles = files.filter(file =>
-      /\.(jpg|jpeg|png|webp)$/i.test(file) &&
-      !file.includes('.optimized.')
+    const imageFiles = files.filter(
+      (file) => /\.(jpg|jpeg|png|webp)$/i.test(file) && !file.includes('.optimized.')
     );
 
     console.log(`📂 Found ${imageFiles.length} images to process\n`);
@@ -189,7 +192,6 @@ Use the generated JSON manifests to automate picture element generation.
     console.log(`   Output directory: ${OUTPUT_DIR}`);
     console.log(`   Formats generated: ${Object.keys(FORMATS).join(', ')}`);
     console.log(`   Responsive breakpoints: ${RESPONSIVE_SIZES.join(', ')}`);
-
   } catch (error) {
     console.error('❌ Error during image optimization:', error);
   }


### PR DESCRIPTION
## What changed
- Promote merged PR #516 from development to testing.
- Carry forward the read-only optimization validation and patched nanoid override.

## Validation
- Development push checks passed: Fast CI, Act Essential Tests, Act Local Testing, and Security & Dependency Scan.
- Main production promotion remains gated on testing checks and a successful Comprehensive CI rerun.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI workflow behavior, optional env paths for a build script, a patch dependency bump, and operational SEO documentation—no runtime auth or data-path changes.
> 
> **Overview**
> **Comprehensive CI** stops writing back to the repo from the optimization job. `pnpm optimize:images` now writes to `OPTIMIZATION_OUTPUT_DIR` (set to runner temp in CI), quality snapshot index drift is **reported** instead of auto-committed, and the former git-auto-commit of optimized images is replaced by a **validation report** (checksums, counts, size) uploaded as an artifact.
> 
> The **image optimizer script** honors optional `OPTIMIZATION_INPUT_DIR` / `OPTIMIZATION_OUTPUT_DIR` so local defaults under `public/assets/images` are unchanged when env vars are unset.
> 
> **Dependency:** `nanoid` override and lockfile move **3.3.17 → 3.3.18**.
> 
> **Docs:** `seo-review.md` latest measurement state is refreshed to **2026-08-10** (production commit, workflow link, Search Console/Bing/Zaraz notes, live-verified query `noindex` behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9665bc539ccdaf22a26f1cf9cecad5a427d221. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->