### PR TITLE
chore(release): promote SEO evidence refresh to testing

### DIFF
--- a/.github/workflows/ci-comprehensive.yml
+++ b/.github/workflows/ci-comprehensive.yml
@@ -267,22 +267,21 @@ jobs:
 
       - name: Run advanced optimizations
         run: pnpm optimize:images
+        env:
+          OPTIMIZATION_OUTPUT_DIR: ${{ runner.temp }}/blakeoxford-optimized-images
 
       - name: Snapshot quality baseline (main only)
         run: pnpm quality:snapshot || true
         if: github.ref == 'refs/heads/main'
 
-      - name: Commit quality snapshot index (if changed)
+      - name: Report quality snapshot changes
         if: github.ref == 'refs/heads/main'
         run: |
           if git diff --quiet quality-snapshots/INDEX.md; then
             echo "No snapshot index changes"
           else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add quality-snapshots/INDEX.md
-            git commit -m "chore(ci): update quality snapshot index [skip ci]" || true
-            git push || echo "Snapshot push race condition; safe to ignore"
+            echo "::notice::Quality snapshot changed in the isolated CI workspace; persistence requires a reviewed pull request."
+            git diff --stat -- quality-snapshots/INDEX.md
           fi
 
       - name: Validate Cloudflare Functions
@@ -296,10 +295,24 @@ jobs:
             echo "⚠️ Warning: Some edge functions may be missing"
           fi
 
-      - name: Commit optimized assets
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_message: '🚀 Automated optimizations [skip ci]'
-          file_pattern: 'public/assets/images/** src/assets/**'
+      - name: Write optimization validation report
+        run: |
+          report_dir="${RUNNER_TEMP}/optimization-report"
+          output_dir="${OPTIMIZATION_OUTPUT_DIR}"
+          mkdir -p "$report_dir"
+          test -d "$output_dir"
+          find "$output_dir" -type f -print0 | sort -z | xargs -0 shasum -a 256 > "$report_dir/files.sha256"
+          find "$output_dir" -type f | wc -l > "$report_dir/file-count.txt"
+          du -sh "$output_dir" > "$report_dir/size.txt"
+          printf 'Optimization output is validation-only. Generated assets are not pushed by CI.\n' > "$report_dir/README.txt"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPTIMIZATION_OUTPUT_DIR: ${{ runner.temp }}/blakeoxford-optimized-images
+
+      - name: Upload optimization validation report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: optimized-assets-validation-${{ github.sha }}
+          path: ${{ runner.temp }}/optimization-report
+          retention-days: 30
+          if-no-files-found: error

--- a/docs/operations/seo-review.md
+++ b/docs/operations/seo-review.md
@@ -61,39 +61,42 @@ implementation does not send or retain the referrer URL, search query, form cont
 address. Use this event as the aggregate organic-contact conversion measure after the analytics
 property is verified.
 
-## Latest recorded measurement state: 2026-08-09
+## Latest recorded measurement state: 2026-08-10
 
-Reviewed 2026-08-09 against production commit `cc228629` and the authenticated personal Search
-Console property:
+Reviewed 2026-08-10 against production commit `1834ffb56f0bbfe15d9d43b449a4adc8b460d107`,
+the authenticated personal Search Console property, and the Cloudflare Zaraz control plane:
 
-- Technical live gates are green: `pnpm monitor:seo` passes all redirect, robots, sitemap,
-  route-wide HTML parity, metadata, and provenance checks across 18 canonical sitemap URLs.
+- Technical live gates are green in [workflow 31346176288](https://github.com/blakeox/blakeoxford.com/actions/runs/31346176288): hosted deployment, provenance, and the repo-scoped NUC smoke pass all redirect, robots, sitemap, route-wide HTML parity, metadata, and provenance checks across 18 canonical sitemap URLs.
 - Google Search Console personal-site property is accessible. The canonical sitemap was submitted,
-  last read on the review date, with 18 discovered pages and 0 videos.
+  with 18 discovered pages and 0 videos in the recorded sitemap receipt.
 - Initial Search Console overview baseline: 9 total web-search clicks, 16 indexed pages,
-  13 not-indexed pages, 10 HTTPS URLs, 0 non-HTTPS URLs, and no Core Web Vitals data yet.
-- Search Console Performance (Web, 3 months, 2026-05-08 through 2026-08-07; updated four hours
-  before review): 737 impressions, 9 clicks, 1.2% average CTR, and 16.7 average position. The
+  14 not-indexed pages, 10 HTTPS URLs, 0 non-HTTPS URLs, and no Core Web Vitals data yet.
+- Search Console Performance (Web, 3 months, 2026-05-08 through 2026-08-07; refreshed 2026-08-10):
+  737 impressions, 9 clicks, 1.2% average CTR, and 16.7 average position. The
   query and landing-page tables were reviewed without copying raw search queries or personal data
   into this repository.
-- Search Console Page indexing (last updated 2026-08-04) reports 13 not-indexed pages across five
+- Search Console Page indexing (last updated 2026-08-06) reports 14 not-indexed pages across five
   reasons: two expected canonical redirects, two expected query-filter canonical alternates, one
-  404, one other 4xx, and seven crawled-but-currently-not-indexed URLs. The historical query
-  surfaces are tracked in #500; the 404/4xx examples remain an external coverage follow-up.
+  404, one other 4xx, and eight crawled-but-currently-not-indexed URLs. The historical query
+  surfaces remain under provider validation in #500; the 404/4xx examples remain an external
+  coverage follow-up.
 - Search Console Unparsable structured data (last updated 2026-08-07) reports two historical
   parsing errors affecting `/projects/ferment-app` and `/blog/building-my-own-local-llm-stack/`.
-  Current production JSON-LD parses successfully for both URLs; Search Console validation remains
-  pending under #501.
-- Bing Webmaster Tools personal property is selected and the canonical sitemap is submitted;
-  status is `Processing` with 0 errors, 0 warnings, and 1 known sitemap. Bing has not yet
-  crawled or discovered URLs.
+  Current production JSON-LD parses successfully for both URLs; provider validation remains
+  `Started` under #501.
+- Bing's connected Microsoft property set currently does not expose `blakeoxford.com`; the earlier
+  personal-property sitemap receipt remains `Processing` with 0 errors, 0 warnings, and 1 known
+  sitemap. No new Bing crawl or performance data is claimed.
+- Cloudflare Zaraz has the GA4 tool enabled with privacy settings that hide IP addresses, user
+  agents, query parameters, and external referrers; the latest configuration publish was
+  2026-08-09. This proves collection is configured, not that a qualified organic lead occurred.
 - Qualified organic contact counts and Bing performance data are still pending. The Search Console
-  aggregate performance baseline is now recorded, but do not treat it as a complete conversion or
+  aggregate performance baseline is recorded, but do not treat it as a complete conversion or
   cross-engine baseline until the remaining fields are captured.
 
-The current branch also adds an edge-level `X-Robots-Tag: noindex, nofollow` response for
-query-bearing HTML requests, addressing the legacy `?filter=` crawl surface tracked in #500. This
-control is not a production receipt until deployed and live-verified.
+The production release also enforces an edge-level `X-Robots-Tag: noindex, nofollow` response for
+query-bearing HTML requests, addressing the legacy `?filter=` crawl surface tracked in #500. The
+control is deployed and live-verified by the NUC smoke; provider exclusion validation remains open.
 
 Facebook validation is intentionally out of scope. X/Twitter card validation remains a separate
 provider-authenticated check.

--- a/docs/operations/seo-review.md
+++ b/docs/operations/seo-review.md
@@ -61,42 +61,49 @@ implementation does not send or retain the referrer URL, search query, form cont
 address. Use this event as the aggregate organic-contact conversion measure after the analytics
 property is verified.
 
-## Latest recorded measurement state: 2026-08-10
+## Latest recorded production and measurement state: 2026-08-13
 
-Reviewed 2026-08-10 against production commit `1834ffb56f0bbfe15d9d43b449a4adc8b460d107`,
-the authenticated personal Search Console property, and the Cloudflare Zaraz control plane:
+Reviewed against production merge `0278cca7b5bf60475460ca55b82f25c2955b69e5`, the
+Cloudflare deployment surface, the protected GitHub release receipts, and the latest available
+authenticated provider snapshot:
 
-- Technical live gates are green in [workflow 31346176288](https://github.com/blakeox/blakeoxford.com/actions/runs/31346176288): hosted deployment, provenance, and the repo-scoped NUC smoke pass all redirect, robots, sitemap, route-wide HTML parity, metadata, and provenance checks across 18 canonical sitemap URLs.
-- Google Search Console personal-site property is accessible. The canonical sitemap was submitted,
-  with 18 discovered pages and 0 videos in the recorded sitemap receipt.
-- Initial Search Console overview baseline: 9 total web-search clicks, 16 indexed pages,
-  14 not-indexed pages, 10 HTTPS URLs, 0 non-HTTPS URLs, and no Core Web Vitals data yet.
-- Search Console Performance (Web, 3 months, 2026-05-08 through 2026-08-07; refreshed 2026-08-10):
-  737 impressions, 9 clicks, 1.2% average CTR, and 16.7 average position. The
-  query and landing-page tables were reviewed without copying raw search queries or personal data
-  into this repository.
-- Search Console Page indexing (last updated 2026-08-06) reports 14 not-indexed pages across five
-  reasons: two expected canonical redirects, two expected query-filter canonical alternates, one
-  404, one other 4xx, and eight crawled-but-currently-not-indexed URLs. The historical query
-  surfaces remain under provider validation in #500; the 404/4xx examples remain an external
-  coverage follow-up.
-- Search Console Unparsable structured data (last updated 2026-08-07) reports two historical
-  parsing errors affecting `/projects/ferment-app` and `/blog/building-my-own-local-llm-stack/`.
-  Current production JSON-LD parses successfully for both URLs; provider validation remains
-  `Started` under #501.
-- Bing's connected Microsoft property set currently does not expose `blakeoxford.com`; the earlier
-  personal-property sitemap receipt remains `Processing` with 0 errors, 0 warnings, and 1 known
-  sitemap. No new Bing crawl or performance data is claimed.
-- Cloudflare Zaraz has the GA4 tool enabled with privacy settings that hide IP addresses, user
-  agents, query parameters, and external referrers; the latest configuration publish was
-  2026-08-09. This proves collection is configured, not that a qualified organic lead occurred.
-- Qualified organic contact counts and Bing performance data are still pending. The Search Console
-  aggregate performance baseline is recorded, but do not treat it as a complete conversion or
-  cross-engine baseline until the remaining fields are captured.
+- Protected promotion completed through [PR #516](https://github.com/blakeox/blakeoxford.com/pull/516),
+  [PR #517](https://github.com/blakeox/blakeoxford.com/pull/517), and
+  [PR #518](https://github.com/blakeox/blakeoxford.com/pull/518).
+- Main [Comprehensive CI run 31760658256](https://github.com/blakeox/blakeoxford.com/actions/runs/31760658256)
+  passed the full test suites, emitted SEO contract, E2E, performance/Lighthouse, and the
+  validation-only Optimization Tasks job. Optimization Tasks passed advanced optimization,
+  Cloudflare Functions validation, validation report generation, and artifact upload without
+  pushing a repository commit.
+- Main [Deployment Status Check 31760658199](https://github.com/blakeox/blakeoxford.com/actions/runs/31760658199),
+  [Push on main 31760657750](https://github.com/blakeox/blakeoxford.com/actions/runs/31760657750),
+  [Fast CI 31760658319](https://github.com/blakeox/blakeoxford.com/actions/runs/31760658319),
+  CodeQL, Security/Dependency Scan, NUC-backed Act Local, and Act Essential all passed.
+- Live smoke returned HTTP 200 for `/`, `/robots.txt`, `/sitemap.xml`,
+  `/projects/?filter=microsoft-fabric`, `/projects/ferment-app`, and
+  `/blog/building-my-own-local-llm-stack/`. Robots points to the canonical `/sitemap.xml`;
+  the filtered project URL emits `noindex`; both historical routes emit JSON-LD.
+- The latest authenticated Google Search Console snapshot remains the 2026-08-10 receipt:
+  the personal-site property had 18 discovered sitemap pages; Performance (2026-05-08 through
+  2026-08-07) showed 737 impressions, 9 clicks, 1.2% average CTR, and 16.7 average position.
+  Page indexing showed 16 indexed and 14 not indexed, including two historical query alternates.
+- Search Console's latest available structured-data receipt still reported two historical parsing
+  errors for `/projects/ferment-app` and `/blog/building-my-own-local-llm-stack/`; current
+  production JSON-LD is valid and #501 remains open for the refreshed provider result.
+- Bing's available property state remains the prior personal-property sitemap receipt in
+  `Processing`, with 0 errors, 0 warnings, and 1 known sitemap; no new Bing crawl or performance
+  data is claimed without an authenticated property receipt.
+- Cloudflare Zaraz remains configured for GA4 with privacy controls that hide IP addresses, user
+  agents, query parameters, and external referrers. This proves collection configuration, not a
+  qualified organic lead. Qualified organic contact counts remain pending.
+- #515 is closed because the production optimization job now validates and uploads artifacts
+  without mutating the repository. #482, #483, #500, and #501 remain open only for their
+  Search Console, Bing, or qualified-organic-measurement acceptance evidence.
 
-The production release also enforces an edge-level `X-Robots-Tag: noindex, nofollow` response for
-query-bearing HTML requests, addressing the legacy `?filter=` crawl surface tracked in #500. The
-control is deployed and live-verified by the NUC smoke; provider exclusion validation remains open.
+The production release enforces an edge-level `X-Robots-Tag: noindex, nofollow` response for
+query-bearing HTML requests, addressing the legacy `?filter=` crawl surface tracked in #500.
+The control is deployed and live-verified; Search Console exclusion/re-crawl confirmation remains
+the provider gate.
 
 Facebook validation is intentionally out of scope. X/Twitter card validation remains a separate
 provider-authenticated check.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   minimatch: 10.2.3
   brace-expansion: '>=5.0.8'
   rollup: 4.59.0
@@ -4739,8 +4739,8 @@ packages:
   mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12167,7 +12167,7 @@ snapshots:
 
   mute-stream@0.0.7: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -12524,7 +12524,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ onlyBuiltDependencies:
   - workerd
 
 overrides:
-  nanoid: '3.3.17'
+  nanoid: '3.3.18'
   minimatch: '10.2.3'
   brace-expansion: '>=5.0.8'
   rollup: '4.59.0'

--- a/scripts/optimization/optimize-images-advanced.js
+++ b/scripts/optimization/optimize-images-advanced.js
@@ -13,15 +13,19 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const INPUT_DIR = path.join(__dirname, '../../public/assets/images');
-const OUTPUT_DIR = path.join(__dirname, '../../public/assets/images/optimized');
+const INPUT_DIR = process.env.OPTIMIZATION_INPUT_DIR
+  ? path.resolve(process.env.OPTIMIZATION_INPUT_DIR)
+  : path.join(__dirname, '../../public/assets/images');
+const OUTPUT_DIR = process.env.OPTIMIZATION_OUTPUT_DIR
+  ? path.resolve(process.env.OPTIMIZATION_OUTPUT_DIR)
+  : path.join(__dirname, '../../public/assets/images/optimized');
 
 // Image optimization configurations
 const FORMATS = {
   avif: { quality: 80, effort: 4 },
   webp: { quality: 85, effort: 4 },
   jpeg: { quality: 85, progressive: true },
-  png: { compressionLevel: 9 }
+  png: { compressionLevel: 9 },
 };
 
 const RESPONSIVE_SIZES = [320, 640, 768, 1024, 1280, 1536, 1920];
@@ -100,7 +104,8 @@ async function optimizeImage(inputPath, filename) {
       // Responsive sizes (only if image is large enough)
       for (const width of responsiveWidths(originalWidth)) {
         const responsiveOutputPath = path.join(formatDir, `${nameWithoutExt}@${width}w.${format}`);
-        await image.clone()
+        await image
+          .clone()
           .resize(width, null, { withoutEnlargement: true })
           // eslint-disable-next-line no-unexpected-multiline
           [format](FORMATS[format])
@@ -114,14 +119,13 @@ async function optimizeImage(inputPath, filename) {
       formats: Object.keys(FORMATS),
       sizes: responsiveWidths(originalWidth),
       width: originalWidth,
-      height: metadata.height
+      height: metadata.height,
     };
 
     const manifestPath = path.join(OUTPUT_DIR, `${nameWithoutExt}.json`);
     await fs.writeFile(manifestPath, JSON.stringify(srcsetData, null, 2));
 
     console.log(`   ✅ Generated ${Object.keys(FORMATS).length} formats with responsive variants`);
-
   } catch (error) {
     console.error(`   ❌ Error processing ${filename}:`, error.message);
   }
@@ -134,9 +138,8 @@ async function generateOptimizedImages() {
 
   try {
     const files = await fs.readdir(INPUT_DIR);
-    const imageFiles = files.filter(file =>
-      /\.(jpg|jpeg|png|webp)$/i.test(file) &&
-      !file.includes('.optimized.')
+    const imageFiles = files.filter(
+      (file) => /\.(jpg|jpeg|png|webp)$/i.test(file) && !file.includes('.optimized.')
     );
 
     console.log(`📂 Found ${imageFiles.length} images to process\n`);
@@ -189,7 +192,6 @@ Use the generated JSON manifests to automate picture element generation.
     console.log(`   Output directory: ${OUTPUT_DIR}`);
     console.log(`   Formats generated: ${Object.keys(FORMATS).join(', ')}`);
     console.log(`   Responsive breakpoints: ${RESPONSIVE_SIZES.join(', ')}`);
-
   } catch (error) {
     console.error('❌ Error during image optimization:', error);
   }


### PR DESCRIPTION
## What changed
- Promote the merged SEO operating-evidence refresh from `development` to `testing`.

## Why
Keep the release branches synchronized before the final production promotion.

## Validation
- Source PR #520 passed all required checks before merging to `development`.
- This is a protected branch-flow promotion; no Facebook work is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI workflow behavior, docs, a small dependency patch, and non-breaking env overrides on the optimizer; no production runtime or auth paths are modified.
> 
> **Overview**
> **CI optimization job** no longer mutates the repository. Automated commits for optimized images (`git-auto-commit-action`) and for `quality-snapshots/INDEX.md` are removed. `pnpm optimize:images` writes to `${{ runner.temp }}/blakeoxford-optimized-images` via `OPTIMIZATION_OUTPUT_DIR`, and a new step builds a checksum/size report and uploads it as a 30-day artifact. Quality snapshot drift on `main` is reported with `::notice::` and `git diff --stat` instead of being pushed.
> 
> **Image pipeline** (`optimize-images-advanced.js`) accepts optional `OPTIMIZATION_INPUT_DIR` and `OPTIMIZATION_OUTPUT_DIR`; default paths under `public/assets/images` are unchanged for local runs.
> 
> **Operations doc** (`docs/operations/seo-review.md`) replaces the 2026-08-09 measurement section with **2026-08-13** production evidence (merge `0278cca7`, CI run links, live smoke, Search Console/Bing receipts). It records that #515 is closed because optimization is validation-only, and that query-bearing HTML `noindex` is **deployed and live-verified** (Search Console re-crawl still pending).
> 
> **Dependencies:** `nanoid` override `3.3.17` → `3.3.18` in `pnpm-workspace.yaml` and lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9350329544a188987e5406673f4358e77b09f528. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->