### PR TITLE
fix(deps): patch undici security advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   minimatch: 10.2.3
   brace-expansion: '>=5.0.8'
   rollup: 4.59.0
-  undici: 7.28.0
+  undici: 7.29.0
   tmp: 0.2.7
   lodash: 4.18.1
   yaml: 2.8.3
@@ -5859,8 +5859,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -7948,7 +7948,7 @@ snapshots:
     dependencies:
       progress: 2.0.3
       proxy-from-env: 1.1.0
-      undici: 7.28.0
+      undici: 7.29.0
       which: 2.0.2
     optionalDependencies:
       '@sentry/cli-darwin': 3.6.2
@@ -10896,7 +10896,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -11678,7 +11678,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@26.1.2)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260730.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -13215,7 +13215,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ overrides:
   minimatch: '10.2.3'
   brace-expansion: '>=5.0.8'
   rollup: '4.59.0'
-  undici: '7.28.0'
+  undici: '7.29.0'
   tmp: '0.2.7'
   lodash: '4.18.1'
   yaml: '2.8.3'


### PR DESCRIPTION
## What changed
- Raise the pnpm workspace override for `undici` from 7.28.0 to patched 7.29.0.
- Regenerate lockfile references and integrity metadata.

## Why
The Sentry Cloudflare update activates `wrangler -> miniflare -> undici`, and the current advisory requires `undici >=7.29.0`.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm security:audit -- --audit-level=high`
- `pnpm run build`
- `git diff --check`

## Risk
Low, dependency-only patch; protected CI remains the merge gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch with no app code changes; risk is limited to HTTP client behavior in dev/tooling transitive deps.
> 
> **Overview**
> Bumps the workspace **`undici`** pnpm override from **7.28.0** to **7.29.0** and refreshes **`pnpm-lock.yaml`** so every resolved copy (including transitive paths such as **`@sentry/cli`**, **jsdom**, and **miniflare** / Wrangler) points at the patched release.
> 
> No application source changes—only dependency resolution to satisfy the advisory requiring **`undici >= 7.29.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f5d27b11d930ca9779dc0ec4cb4f8a6650fc6d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->