### PR TITLE
test(e2e): harden lazy search readiness

### DIFF
--- a/tests/utils/pageActions.ts
+++ b/tests/utils/pageActions.ts
@@ -117,6 +117,10 @@ export async function openSearchOverlay(page: Page) {
 
 export async function fillSearch(page: Page, query: string) {
   const input = page.locator('#search-input');
+  // The command center is intentionally lazy-mounted. Firefox can take longer
+  // than Chromium/WebKit to commit the first React render after the overlay
+  // shell opens, so wait for the actual control before mutating its state.
+  await input.waitFor({ state: 'attached', timeout: 10000 });
   // Ensure input is visible and enabled; some overlays toggle attributes asynchronously
   await page.evaluate(() => {
     try {
@@ -131,7 +135,8 @@ export async function fillSearch(page: Page, query: string) {
       input.setAttribute('aria-expanded', 'true');
     } catch (e) { console.error('ensure input visible failed', e); }
   }).catch(() => {});
-  await input.fill(query);
+  await expect(input).toBeVisible({ timeout: 10000 });
+  await input.fill(query, { timeout: 10000 });
   const results = page.locator('[data-search-result], .search-result, .search-overlay [role="listbox"] [role="option"]');
   // Wait for at least one visible result to avoid strict mode multiple element error
   await page.waitForFunction(() => {


### PR DESCRIPTION
## What changed
- Wait for the lazily mounted search input to attach and become visible before filling it.
- Increase only the bounded search-control action timeout for Firefox/WebKit startup variance.

## Why
The optional macOS Firefox/WebKit gate reproduced a Firefox-only timeout while waiting for `#search-input`; Chromium and WebKit passed. This removes the race from the test helper without changing production behavior.

## Impact
Test-only change; no runtime or SEO behavior changes.

## Testing
- Prettier check passed.
- `git diff --check` passed.
- Protected GitHub checks required before merge.

## Risk
Low and reversible. The helper still fails if the search control does not mount within the bounded timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper change in `tests/utils/pageActions.ts`; no production or runtime impact, and failures still occur if the control never mounts within the bounded timeout.
> 
> **Overview**
> Hardens the Playwright **`fillSearch`** helper so it no longer fills `#search-input` before the lazily mounted command-center control exists in the DOM.
> 
> After the existing visibility-enabling `evaluate`, it now **waits up to 10s** for the input to attach and become visible, then calls **`fill`** with the same **10s** action timeout. This targets Firefox-only flakes where the overlay shell opens before the first React render commits the search field; production behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b43a7d534479c2992ff192791c55ca852038301. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->