### PR TITLE
test(e2e): preserve search dialog in fixture cleanup

### DIFF
--- a/tests/playwright/fixtures.ts
+++ b/tests/playwright/fixtures.ts
@@ -105,7 +105,13 @@ export const test = base.extend({
             selectors.forEach((sel) => {
               document.querySelectorAll(sel).forEach((el) => {
                 try {
-                  if (el.id === 'nav-mobile-links' || el.id === 'search-overlay') return;
+                  if (
+                    el.id === 'nav-mobile-links' ||
+                    el.id === 'search-overlay' ||
+                    el.closest('#search-overlay')
+                  ) {
+                    return;
+                  }
                   const text = (el.textContent || '').toLowerCase();
                   if (
                     sel !== 'dialog' ||

--- a/tests/utils/pageActions.ts
+++ b/tests/utils/pageActions.ts
@@ -117,10 +117,6 @@ export async function openSearchOverlay(page: Page) {
 
 export async function fillSearch(page: Page, query: string) {
   const input = page.locator('#search-input');
-  // The command center is intentionally lazy-mounted. Firefox can take longer
-  // than Chromium/WebKit to commit the first React render after the overlay
-  // shell opens, so wait for the actual control before mutating its state.
-  await input.waitFor({ state: 'attached', timeout: 10000 });
   // Ensure input is visible and enabled; some overlays toggle attributes asynchronously
   await page.evaluate(() => {
     try {
@@ -135,8 +131,7 @@ export async function fillSearch(page: Page, query: string) {
       input.setAttribute('aria-expanded', 'true');
     } catch (e) { console.error('ensure input visible failed', e); }
   }).catch(() => {});
-  await expect(input).toBeVisible({ timeout: 10000 });
-  await input.fill(query, { timeout: 10000 });
+  await input.fill(query);
   const results = page.locator('[data-search-result], .search-result, .search-overlay [role="listbox"] [role="option"]');
   // Wait for at least one visible result to avoid strict mode multiple element error
   await page.waitForFunction(() => {


### PR DESCRIPTION
## What changed
- Exclude the search overlay and all of its descendants from the AI-assistant fixture cleanup observer.
- Remove the timeout-only search helper workaround now that the fixture scope is correct.

## Why
Firefox exposed that the fixture's generic `[role="dialog"]` cleanup could remove the lazily mounted search panel after the shell opened. Chromium and WebKit did not reproduce the timing.

## Impact
Test-only change; production search code is unchanged.

## Testing
- Local Firefox reproduction reached the search result assertion after the fixture correction instead of failing to find `#search-input`.
- Prettier and `git diff --check` passed.
- Protected GitHub checks required before merge.

## Risk
Low and reversible; AI-assistant cleanup remains unchanged outside the search overlay subtree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to fixture cleanup and page helpers; production search behavior is unchanged.
> 
> **Overview**
> Fixes flaky Firefox e2e failures where **`#search-input`** disappeared after the search shell opened.
> 
> The Playwright fixture’s AI-assistant DOM cleanup now **skips `#search-overlay` and every descendant** (via `closest('#search-overlay')`), so the broad `[role="dialog"]` rule no longer tears down the lazily mounted search panel.
> 
> With that scope corrected, **`fillSearch`** drops the extra 10s waits on attach/visibility/fill and uses the default **`input.fill(query)`** again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ce52a18dfdf4725012d34798587de361355c50. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->