### PR TITLE
fix(seo): rewrite fallback metadata for query URLs

### DIFF
--- a/functions/routes/assets.ts
+++ b/functions/routes/assets.ts
@@ -160,7 +160,7 @@ export async function handleAssets({
               dur: Date.now() - startTs,
             })
           );
-          return resp;
+          return addQueryNoindexMeta(resp, url);
         }
         // Graceful fallbacks for non-HTML requests during transient failures
         const pathname = url.pathname;
@@ -478,7 +478,7 @@ export async function handleAssets({
           dur: Date.now() - errStart,
         })
       );
-      return resp;
+      return addQueryNoindexMeta(resp, url);
     }
     return new Response('Not found', {
       status: 404,

--- a/tests/vitest/edge/assets.edge.test.ts
+++ b/tests/vitest/edge/assets.edge.test.ts
@@ -100,6 +100,31 @@ describe('asset route cache and failure contract', () => {
     expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow" />');
   });
 
+  it('rewrites offline HTML returned for query-bearing origin failures', async () => {
+    const ctx = context(
+      '/projects/?filter=healthcare-it',
+      new Response('origin unavailable', { status: 503 })
+    );
+
+    const response = await handleAssets(ctx);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow" />');
+  });
+
+  it('rewrites offline HTML returned after an asset fetch exception', async () => {
+    const ctx = context(
+      '/projects/?filter=healthcare-it',
+      new Response('<html><head><meta name="robots" content="index, follow"></head></html>')
+    );
+    ctx.env.ASSETS.fetch.mockRejectedValue(new Error('origin unavailable'));
+
+    const response = await handleAssets(ctx);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow" />');
+  });
+
   it('clears entity headers even when the query robots tag is already correct', async () => {
     const response = await addQueryNoindexMeta(
       new Response('<html><head><meta name="robots" content="noindex, nofollow" /></head></html>', {


### PR DESCRIPTION
## What changed
- apply the query URL robots-meta rewrite to offline HTML returned for origin 5xx responses
- apply the same rewrite to exception-path offline HTML responses
- add focused edge tests for both fallback paths

## Why
Query-bearing HTML is intentionally excluded from indexing at the edge. Every HTML fallback must carry the same `noindex, nofollow` directive in markup as the response header.

## Validation
- focused edge tests: 15 passed
- Prettier check passed
- `pnpm typecheck` passed: 351 files, 0 diagnostics
- pre-push typecheck and lint passed

## Scope
No production deployment or branch-policy changes are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small SEO markup change on existing HTML fallbacks only; no auth, caching contract, or routing behavior changes.
> 
> **Overview**
> Query-bearing HTML fallbacks now get the same `noindex, nofollow` robots meta rewrite as successful responses.
> 
> `handleAssets` runs `addQueryNoindexMeta` on offline HTML for origin 5xx and asset-fetch exceptions, so crawlers do not index query URLs served during outages. Edge tests cover both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d461c00b7c1c7c1500bcaa97773b103ed970140. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->