### PR TITLE
fix(seo): preserve partial response integrity

### DIFF
--- a/functions/routes/assets.ts
+++ b/functions/routes/assets.ts
@@ -353,7 +353,11 @@ export async function handleAssets({
       if (themeCookie) {
         const decodedThemeCookie = decodeURIComponent(themeCookie);
         const contentType = finalResponse.headers.get('content-type') || '';
-        if (contentType.includes('text/html') && decodedThemeCookie !== 'system') {
+        if (
+          contentType.includes('text/html') &&
+          decodedThemeCookie !== 'system' &&
+          finalResponse.status !== 206
+        ) {
           let html = await finalResponse.text();
           html = html.replace(/<html([^>]*)>/i, (full, attrs) => {
             let newAttrs = attrs || '';

--- a/functions/routes/assets.ts
+++ b/functions/routes/assets.ts
@@ -10,7 +10,13 @@ const ROBOTS_META_PATTERN = /<meta\b(?=[^>]*\bname=["']robots["'])[^>]*>/i;
 /** Keep query-bearing HTML crawl policy consistent in both headers and markup. */
 export async function addQueryNoindexMeta(response: Response, url: URL): Promise<Response> {
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
-  if (!url.search || !contentType.includes('text/html') || !response.body) return response;
+  if (
+    !url.search ||
+    response.status === 206 ||
+    !contentType.includes('text/html') ||
+    !response.body
+  )
+    return response;
 
   const html = await response.text();
   const rewritten = ROBOTS_META_PATTERN.test(html)
@@ -210,13 +216,14 @@ export async function handleAssets({
         h.set('x-route-kind', routeKind);
         const cc = h.get('cache-control') || 'no-store';
         h.set('x-cache-policy', cc);
-        return new Response(originResponse.body, {
+        const response = new Response(originResponse.body, {
           status: originResponse.status,
           statusText: originResponse.statusText,
           headers: h,
         });
+        return addQueryNoindexMeta(response, url);
       } catch {
-        return originResponse;
+        return addQueryNoindexMeta(originResponse, url);
       }
     }
 

--- a/tests/vitest/edge/assets.edge.test.ts
+++ b/tests/vitest/edge/assets.edge.test.ts
@@ -157,6 +157,27 @@ describe('asset route cache and failure contract', () => {
     expect(await response.text()).toContain('content="index, follow"');
   });
 
+  it('does not personalize partial HTML responses', async () => {
+    const ctx = context(
+      '/projects/?filter=healthcare-it',
+      new Response('<html><head></head><body>partial</body></html>', {
+        status: 206,
+        headers: {
+          'content-type': 'text/html; charset=utf-8',
+          'content-range': 'bytes 0-10/45',
+        },
+      }),
+      { cookie: 'theme=dark' }
+    );
+
+    const response = await handleAssets(ctx);
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('content-range')).toBe('bytes 0-10/45');
+    expect(response.headers.get('cache-control')).not.toContain('private');
+    expect(await response.text()).not.toContain('data-theme="dark"');
+  });
+
   it('clears entity headers even when the query robots tag is already correct', async () => {
     const response = await addQueryNoindexMeta(
       new Response('<html><head><meta name="robots" content="noindex, nofollow" /></head></html>', {

--- a/tests/vitest/edge/assets.edge.test.ts
+++ b/tests/vitest/edge/assets.edge.test.ts
@@ -125,6 +125,38 @@ describe('asset route cache and failure contract', () => {
     expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow" />');
   });
 
+  it('rewrites query-bearing HTML returned as a non-5xx origin error', async () => {
+    const ctx = context(
+      '/projects/?filter=healthcare-it',
+      new Response('<html><head><meta name="robots" content="index, follow"></head></html>', {
+        status: 404,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      })
+    );
+
+    const response = await handleAssets(ctx);
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow" />');
+  });
+
+  it('does not rewrite partial HTML responses', async () => {
+    const response = await addQueryNoindexMeta(
+      new Response('<html><head><meta name="robots" content="index, follow"></head></html>', {
+        status: 206,
+        headers: {
+          'content-type': 'text/html; charset=utf-8',
+          'content-range': 'bytes 0-10/80',
+        },
+      }),
+      new URL('https://blakeoxford.com/projects/?filter=healthcare-it')
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('content-range')).toBe('bytes 0-10/80');
+    expect(await response.text()).toContain('content="index, follow"');
+  });
+
   it('clears entity headers even when the query robots tag is already correct', async () => {
     const response = await addQueryNoindexMeta(
       new Response('<html><head><meta name="robots" content="noindex, nofollow" /></head></html>', {


### PR DESCRIPTION
## What changed
- apply query robots metadata rewriting to non-5xx HTML error responses
- skip rewriting `206 Partial Content` responses so byte ranges and entity headers remain valid
- add focused tests for 404 HTML and partial HTML behavior

## Why
The query URL policy must cover HTML error responses, but rewriting a partial response would change its body while retaining range semantics. This closes both edge cases without changing the normal response contract.

## Validation
- focused edge tests: 17 passed
- Prettier check passed
- `pnpm typecheck` passed: 351 files, 0 diagnostics
- pre-push typecheck and lint passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow edge HTML rewrite tweak for crawl metadata and range responses; no auth, data, or cache-contract changes.
> 
> **Overview**
> Query-bearing HTML now gets the noindex robots meta on **non-5xx origin errors** (e.g. 404), not only successful and 5xx fallback paths.
> 
> `addQueryNoindexMeta` **skips `206 Partial Content`**, so range bodies and entity headers are not rewritten. Tests cover 404 query HTML and the 206 skip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c890935e250dcb196441978dbc6c388dc6bbcf13. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->