### PR TITLE
chore(release): promote hardened SEO policy to testing

### DIFF
--- a/functions/routes/assets.ts
+++ b/functions/routes/assets.ts
@@ -353,7 +353,11 @@ export async function handleAssets({
       if (themeCookie) {
         const decodedThemeCookie = decodeURIComponent(themeCookie);
         const contentType = finalResponse.headers.get('content-type') || '';
-        if (contentType.includes('text/html') && decodedThemeCookie !== 'system') {
+        if (
+          contentType.includes('text/html') &&
+          decodedThemeCookie !== 'system' &&
+          finalResponse.status !== 206
+        ) {
           let html = await finalResponse.text();
           html = html.replace(/<html([^>]*)>/i, (full, attrs) => {
             let newAttrs = attrs || '';

--- a/functions/routes/assets.ts
+++ b/functions/routes/assets.ts
@@ -10,7 +10,13 @@ const ROBOTS_META_PATTERN = /<meta\b(?=[^>]*\bname=["']robots["'])[^>]*>/i;
 /** Keep query-bearing HTML crawl policy consistent in both headers and markup. */
 export async function addQueryNoindexMeta(response: Response, url: URL): Promise<Response> {
   const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
-  if (!url.search || !contentType.includes('text/html') || !response.body) return response;
+  if (
+    !url.search ||
+    response.status === 206 ||
+    !contentType.includes('text/html') ||
+    !response.body
+  )
+    return response;
 
   const html = await response.text();
   const rewritten = ROBOTS_META_PATTERN.test(html)
@@ -210,13 +216,14 @@ export async function handleAssets({
         h.set('x-route-kind', routeKind);
         const cc = h.get('cache-control') || 'no-store';
         h.set('x-cache-policy', cc);
-        return new Response(originResponse.body, {
+        const response = new Response(originResponse.body, {
           status: originResponse.status,
           statusText: originResponse.statusText,
           headers: h,
         });
+        return addQueryNoindexMeta(response, url);
       } catch {
-        return originResponse;
+        return addQueryNoindexMeta(originResponse, url);
       }
     }
 

--- a/tests/vitest/edge/assets.edge.test.ts
+++ b/tests/vitest/edge/assets.edge.test.ts
@@ -157,6 +157,27 @@ describe('asset route cache and failure contract', () => {
     expect(await response.text()).toContain('content="index, follow"');
   });
 
+  it('does not personalize partial HTML responses', async () => {
+    const ctx = context(
+      '/projects/?filter=healthcare-it',
+      new Response('<html><head></head><body>partial</body></html>', {
+        status: 206,
+        headers: {
+          'content-type': 'text/html; charset=utf-8',
+          'content-range': 'bytes 0-10/45',
+        },
+      }),
+      { cookie: 'theme=dark' }
+    );
+
+    const response = await handleAssets(ctx);
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('content-range')).toBe('bytes 0-10/45');
+    expect(response.headers.get('cache-control')).not.toContain('private');
+    expect(await response.text()).not.toContain('data-theme="dark"');
+  });
+
   it('clears entity headers even when the query robots tag is already correct', async () => {
     const response = await addQueryNoindexMeta(
       new Response('<html><head><meta name="robots" content="noindex, nofollow" /></head></html>', {

--- a/tests/vitest/edge/assets.edge.test.ts
+++ b/tests/vitest/edge/assets.edge.test.ts
@@ -125,6 +125,38 @@ describe('asset route cache and failure contract', () => {
     expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow" />');
   });
 
+  it('rewrites query-bearing HTML returned as a non-5xx origin error', async () => {
+    const ctx = context(
+      '/projects/?filter=healthcare-it',
+      new Response('<html><head><meta name="robots" content="index, follow"></head></html>', {
+        status: 404,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      })
+    );
+
+    const response = await handleAssets(ctx);
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow" />');
+  });
+
+  it('does not rewrite partial HTML responses', async () => {
+    const response = await addQueryNoindexMeta(
+      new Response('<html><head><meta name="robots" content="index, follow"></head></html>', {
+        status: 206,
+        headers: {
+          'content-type': 'text/html; charset=utf-8',
+          'content-range': 'bytes 0-10/80',
+        },
+      }),
+      new URL('https://blakeoxford.com/projects/?filter=healthcare-it')
+    );
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get('content-range')).toBe('bytes 0-10/80');
+    expect(await response.text()).toContain('content="index, follow"');
+  });
+
   it('clears entity headers even when the query robots tag is already correct', async () => {
     const response = await addQueryNoindexMeta(
       new Response('<html><head><meta name="robots" content="noindex, nofollow" /></head></html>', {


### PR DESCRIPTION
## What changed
- promote the hardened query URL SEO policy from `development` to `testing`
- include non-5xx HTML fallback coverage
- preserve 206 partial-response body and range/entity semantics, including theme-cookie requests

## Why
This is the protected release step following the final review fixes in PR #580 and reconciliation PR #581.

## Validation
- PR #580 merged the implementation into `development`
- PR #581 reconciled branch history and passed all required checks
- local focused edge tests: 18 passed
- local Astro typecheck: 351 files, 0 diagnostics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches edge HTML rewriting and cache/personalization paths; incorrect 206 handling could break range responses or leak/cache personalized HTML.
> 
> **Overview**
> Hardens query-URL SEO rewriting so crawlers still get `noindex` on non-5xx HTML (e.g. 404s), while **206 partial responses are left untouched**.
> 
> `addQueryNoindexMeta` now bails on status `206` so range/entity headers and partial bodies stay intact. Theme-cookie HTML personalization is skipped for the same status so range requests are not rewritten into private full documents.
> 
> Non-5xx origin error HTML now runs through the same noindex rewrite as success and 5xx fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c57a5a49458ea31b5ae2fd7579ecd4864c9b3f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->